### PR TITLE
fix: make sure parameters generated from DqlSelection start with a letter

### DIFF
--- a/src/Kdyby/Doctrine/Dql/Condition.php
+++ b/src/Kdyby/Doctrine/Dql/Condition.php
@@ -167,7 +167,7 @@ class Condition extends Nette\Object
 	public function build(ArrayCollection $parameters)
 	{
 		$cond = explode('?', $serialised = $this->__toString());
-		$prefix = substr(md5($serialised), 0, 5);
+		$prefix = 'h' . substr(md5($serialised), 0, 5); // must start with letter otherwise doctrine lexer won't take it correctly
 
 		$result = array_shift($cond);
 		foreach ($this->params as $i => $value) {

--- a/tests/KdybyTests/Doctrine/Condition.phpt
+++ b/tests/KdybyTests/Doctrine/Condition.phpt
@@ -97,30 +97,30 @@ class ConditionTest extends Tester\TestCase
 		$condition->addAnd('column', array(10, 20, 30));
 
 		$params = new ArrayCollection();
-		Assert::same("column IN (:9c25e_0_0, :9c25e_0_1, :9c25e_0_2)", $condition->build($params));
+		Assert::same("column IN (:h9c25e_0_0, :h9c25e_0_1, :h9c25e_0_2)", $condition->build($params));
 		Assert::equal(array(
-			':9c25e_0_0' => new Parameter('9c25e_0_0', 10),
-			':9c25e_0_1' => new Parameter('9c25e_0_1', 20),
-			':9c25e_0_2' => new Parameter('9c25e_0_2', 30),
+			':h9c25e_0_0' => new Parameter('h9c25e_0_0', 10),
+			':h9c25e_0_1' => new Parameter('h9c25e_0_1', 20),
+			':h9c25e_0_2' => new Parameter('h9c25e_0_2', 30),
 		), $params->toArray());
 
 		$condition = new Condition();
 		$condition->addAnd('column', array(10, 20));
 
 		$params = new ArrayCollection();
-		Assert::same("column IN (:9c25e_0_0, :9c25e_0_1)", $condition->build($params));
+		Assert::same("column IN (:h9c25e_0_0, :h9c25e_0_1)", $condition->build($params));
 		Assert::equal(array(
-			':9c25e_0_0' => new Parameter('9c25e_0_0', 10),
-			':9c25e_0_1' => new Parameter('9c25e_0_1', 20),
+			':h9c25e_0_0' => new Parameter('h9c25e_0_0', 10),
+			':h9c25e_0_1' => new Parameter('h9c25e_0_1', 20),
 		), $params->toArray());
 
 		$condition = new Condition();
 		$condition->addAnd('column', array(10));
 
 		$params = new ArrayCollection();
-		Assert::same("column IN (:9c25e_0_0)", $condition->build($params));
+		Assert::same("column IN (:h9c25e_0_0)", $condition->build($params));
 		Assert::equal(array(
-			':9c25e_0_0' => new Parameter('9c25e_0_0', 10),
+			':h9c25e_0_0' => new Parameter('h9c25e_0_0', 10),
 		), $params->toArray());
 	}
 
@@ -132,9 +132,9 @@ class ConditionTest extends Tester\TestCase
 		$condition->addAnd('column', 10);
 
 		$params = new ArrayCollection();
-		Assert::same("column = :126fc_0_0", $condition->build($params));
+		Assert::same("column = :h126fc_0_0", $condition->build($params));
 		Assert::equal(array(
-			':126fc_0_0' => new Parameter('126fc_0_0', 10),
+			':h126fc_0_0' => new Parameter('h126fc_0_0', 10),
 		), $params->toArray());
 	}
 

--- a/tests/KdybyTests/Doctrine/DqlSelection.phpt
+++ b/tests/KdybyTests/Doctrine/DqlSelection.phpt
@@ -523,10 +523,10 @@ class DqlSelectionTest extends KdybyTests\ORMTestCase
 			->where('u.id = ?', 23)
 			->where('u.id', 87);
 
-		Assert::match('SELECT u FROM test:CmsUser u WHERE u.id = :5f727_0_0 AND u.id = :5f727_1_0', $qb->getDQL());
+		Assert::match('SELECT u FROM test:CmsUser u WHERE u.id = :h5f727_0_0 AND u.id = :h5f727_1_0', $qb->getDQL());
 		Assert::equal(array(
-			':5f727_0_0' => new Parameter('5f727_0_0', 23),
-			':5f727_1_0' => new Parameter('5f727_1_0', 87),
+			':h5f727_0_0' => new Parameter('h5f727_0_0', 23),
+			':h5f727_1_0' => new Parameter('h5f727_1_0', 87),
 		), $qb->getParameters()->toArray());
 	}
 


### PR DESCRIPTION
otherwise doctrine lexer won't take it correctly
