### PR TITLE
Fix error after recent changes in Nette

### DIFF
--- a/src/Kdyby/Doctrine/Diagnostics/Panel.php
+++ b/src/Kdyby/Doctrine/Diagnostics/Panel.php
@@ -580,7 +580,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 		/** @var Panel $panel */
 
 		$panel->setConnection($connection);
-		$panel->registerBarPanel(Debugger::$bar);
+		$panel->registerBarPanel(Debugger::getBar());
 		Debugger::$blueScreen->addPanel(callback($panel, 'renderQueryException'));
 
 		return $panel;
@@ -605,7 +605,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 	 */
 	public static function registerBluescreen()
 	{
-		Debugger::$blueScreen->addPanel(callback(get_called_class() . '::renderException'));
+		Debugger::getBlueScreen()->addPanel(callback(get_called_class() . '::renderException'));
 	}
 
 }


### PR DESCRIPTION
After https://github.com/nette/nette/commit/7ac95d7127546c1819ec9704305ea3ce3a1e027c, variables $blueScreen and $bar did return `NULL` - getBlueScreen and getBar is the correct usage, i think :)
