### PR TITLE
Fix mapping naming strategy

### DIFF
--- a/src/Kdyby/Doctrine/Mapping/ClassMetadataFactory.php
+++ b/src/Kdyby/Doctrine/Mapping/ClassMetadataFactory.php
@@ -33,16 +33,4 @@ class ClassMetadataFactory extends Doctrine\ORM\Mapping\ClassMetadataFactory
 	}
 
 
-
-	/**
-	 * Creates a new ClassMetadata instance for the given class name.
-	 *
-	 * @param string $className
-	 * @return ClassMetadata
-	 */
-	protected function newClassMetadataInstance($className)
-	{
-		return new ClassMetadata($className);
-	}
-
 }


### PR DESCRIPTION
Doctrine\ORM\Mapping\ClassMetadataInfo expects NamingStrategy in constructor. If there is not, DefaultNamingStrategy is used (even if I define my own in configuration) This hopefully fixes the problem.
