### PR TITLE
Fixed error if config section is empty

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -151,7 +151,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		}
 
 		foreach ($config as $name => $emConfig) {
-			if (empty($emConfig)) {
+			if (!is_array($emConfig)) {
 				throw new Kdyby\Doctrine\UnexpectedValueException("Please configure the Doctrine extensions using the section 'doctrine:' in your config file.");
 			}
 


### PR DESCRIPTION
Instead of the exception I got this:
Recoverable Error
Argument 2 passed to Kdyby\Doctrine\DI\OrmExtension::processEntityManager() must be of the type array, boolean given, called in E:\Media33\m33\deployer\vendor\kdyby\doctrine\src\Kdyby\Doctrine\DI\OrmExtension.php on line 158 and defined
