### PR TITLE
BaseEntity was declaring nonexistent id field in phpdoc

### DIFF
--- a/src/Kdyby/Doctrine/Entities/BaseEntity.php
+++ b/src/Kdyby/Doctrine/Entities/BaseEntity.php
@@ -25,8 +25,6 @@ use Kdyby\Doctrine\UnexpectedValueException;
  * @author Filip Procházka <filip@prochazka.su>
  *
  * @ORM\MappedSuperclass()
- *
- * @property-read int $id
  */
 abstract class BaseEntity extends Nette\Object implements \Serializable
 {


### PR DESCRIPTION
Either it need explanation why is it there or is just old code.
Named and Identified entities define their own id property or setters and getters
