### PR TITLE
EM::getRepository was creating multiple repositories for same entity

### DIFF
--- a/src/Kdyby/Doctrine/EntityManager.php
+++ b/src/Kdyby/Doctrine/EntityManager.php
@@ -101,6 +101,10 @@ class EntityManager extends Doctrine\ORM\EntityManager
 		}
 
 		$metadata = $this->getClassMetadata($entityName);
+		if ($metadata->name !== $entityName) {
+			return $this->repositories[$entityName] = $this->getRepository($metadata->name);
+		}
+
 		if (!$daoClassName = $metadata->customRepositoryClassName) {
 			$daoClassName = $this->getConfiguration()->getDefaultRepositoryClassName();
 		}


### PR DESCRIPTION
When using interface or entity name instead of full class name.

Hope it passes (blind pull) :).
