### PR TITLE
Safe was checking for Collection instead of Traversable

### DIFF
--- a/src/Kdyby/Doctrine/EntityDao.php
+++ b/src/Kdyby/Doctrine/EntityDao.php
@@ -429,7 +429,7 @@ class EntityDao extends Doctrine\ORM\EntityRepository implements Persistence\Obj
 
 	/**
 	 * @param array|string|\Traversable $args
-	 * @return array
+	 * @return array|\Traversable
 	 */
 	private static function iterableArgs($args)
 	{


### PR DESCRIPTION
[EntityDao::iterableArgs](https://github.com/mishak87/Doctrine/blob/fc95bf2c0b2b8fb8a373b4d5dacfb53db1ece3a2/src/Kdyby/Doctrine/EntityDao.php#L440) is checking for Traversable not a Collection. (inconsistency)
