### PR TITLE
Added method 'fetchCount' to EntityDao

### DIFF
--- a/src/Kdyby/Doctrine/EntityDao.php
+++ b/src/Kdyby/Doctrine/EntityDao.php
@@ -330,6 +330,23 @@ class EntityDao extends Doctrine\ORM\EntityRepository implements Persistence\Obj
 
 	/**
 	 * @param \Kdyby\Persistence\Query|\Kdyby\Doctrine\QueryObject $queryObject
+	 * @throws QueryException
+	 * @return integer
+	 */
+	public function fetchCount(Persistence\Query $queryObject)
+	{
+		try {
+			return $queryObject->count($this);
+
+		} catch (\Exception $e) {
+			throw $this->handleQueryException($e, $queryObject);
+		}
+	}
+
+
+
+	/**
+	 * @param \Kdyby\Persistence\Query|\Kdyby\Doctrine\QueryObject $queryObject
 	 *
 	 * @throws InvalidStateException
 	 * @throws QueryException


### PR DESCRIPTION
Method `count` could not be used in a good way (with exception handling) so this adds method which allows it directly using `EntityDao`.

If this is not a way how it should be used then method `count` should not be on `QueryObject` (at least not public).
