### PR TITLE
Enable one entity namespace in multiple folders

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -252,7 +252,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			if ($extension instanceof IEntityProvider) {
 				$metadata = $extension->getEntityMappings();
 				Validators::assert($metadata, 'array:1..');
-				$config['metadata'] = array_merge($config['metadata'], $metadata);
+				$config['metadata'] = array_merge_recursive($config['metadata'], $metadata);
 			}
 
 			if ($extension instanceof ITargetEntityProvider) {


### PR DESCRIPTION
With array_merge, only last namespace is used. In this case `%appDir%/model` would be overriden.

Use case for this fix:

**config.neon**

``` yaml
doctrine:
    metadata:
        App:
            - %appDir%/model
```

**Extension.php**

``` php
class Extension extends CompilerExtension implements IEntityProvider
{

    /**
     * @return string[]
     */
    public function getEntityMappings()
    {
        return ['App' => [__DIR__ . '/../model']];
    }

}
```
