### PR TITLE
AnnotationDriver: usage of setFileExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"nette/nette": "~2.1@dev",
-		"doctrine/orm": "~2.4",
+		"doctrine/orm": "~2.4.1",
 		"kdyby/events": "~2.0@dev",
 		"kdyby/console": "~2.0@dev",
 		"kdyby/annotations": "~2.0@dev",

--- a/src/Kdyby/Doctrine/Mapping/AnnotationDriver.php
+++ b/src/Kdyby/Doctrine/Mapping/AnnotationDriver.php
@@ -18,9 +18,17 @@ use Nette;
 
 /**
  * @author Filip Procházka <filip@prochazka.su>
+ * @author Josef Kříž <pepakriz@gmail.com>
  */
 class AnnotationDriver extends Doctrine\ORM\Mapping\Driver\AnnotationDriver
 {
+
+	/**
+	 * @var array
+	 */
+	protected $fileExtensions;
+
+
 
 	/**
 	 * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading phpdoc annotations.
@@ -31,6 +39,55 @@ class AnnotationDriver extends Doctrine\ORM\Mapping\Driver\AnnotationDriver
 	public function __construct(array $paths, Doctrine\Common\Annotations\Reader $reader)
 	{
 		parent::__construct($reader, $paths);
+	}
+
+
+
+	/**
+	 * @param array $fileExtensions
+	 */
+	public function setFileExtensions($fileExtensions)
+	{
+		$this->fileExtensions = $fileExtensions;
+	}
+
+
+
+	/**
+	 * @return array
+	 */
+	public function getFileExtensions()
+	{
+		return $this->fileExtensions;
+	}
+
+
+
+	public function getAllClassNames()
+	{
+		if ($this->classNames !== NULL) {
+			return $this->classNames;
+		}
+
+		$classes = array();
+		$paths = $this->paths;
+		$fileExtensions = $this->fileExtension;
+
+		foreach ((array)$paths as $path) {
+			$exts = isset($this->fileExtensions[$path]) ? $this->fileExtensions[$path] : $this->fileExtension;
+
+			foreach ((array)$exts as $ext) {
+				$this->paths = array($path);
+				$this->classNames = NULL;
+				$this->fileExtension = $ext;
+
+				$classes = array_unique(array_merge($classes, parent::getAllClassNames()));
+			}
+		}
+
+		$this->paths = $paths;
+		$this->fileExtension = $fileExtensions;
+		return $this->classNames = $classes;
 	}
 
 }


### PR DESCRIPTION
Metadata can contain `*` as separator between path and file extension.
