### PR TITLE
Nette 2.2beta compatible

### DIFF
--- a/src/Kdyby/Doctrine/Console/GenerateProxiesCommand.php
+++ b/src/Kdyby/Doctrine/Console/GenerateProxiesCommand.php
@@ -15,7 +15,12 @@ use Kdyby;
 use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tracy\Debugger;
 
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+}
 
 
 /**
@@ -43,7 +48,7 @@ class GenerateProxiesCommand extends Doctrine\ORM\Tools\Console\Command\Generate
 	{
 		parent::initialize($input, $output);
 		$this->cacheStorage->clean(array(Nette\Caching\Cache::ALL => TRUE));
-		Nette\Diagnostics\Debugger::$productionMode = FALSE;
+		Debugger::$productionMode = FALSE;
 	}
 
 }

--- a/src/Kdyby/Doctrine/Console/InfoCommand.php
+++ b/src/Kdyby/Doctrine/Console/InfoCommand.php
@@ -15,7 +15,12 @@ use Kdyby;
 use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tracy\Debugger;
 
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+}
 
 
 /**
@@ -43,7 +48,7 @@ class InfoCommand extends Doctrine\ORM\Tools\Console\Command\InfoCommand
 	{
 		parent::initialize($input, $output);
 		$this->cacheStorage->clean(array(Nette\Caching\Cache::ALL => TRUE));
-		Nette\Diagnostics\Debugger::$productionMode = FALSE;
+		Debugger::$productionMode = FALSE;
 	}
 
 }

--- a/src/Kdyby/Doctrine/Console/SchemaCreateCommand.php
+++ b/src/Kdyby/Doctrine/Console/SchemaCreateCommand.php
@@ -16,7 +16,12 @@ use Kdyby;
 use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tracy\Debugger;
 
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+}
 
 
 /**
@@ -47,7 +52,7 @@ class SchemaCreateCommand extends Doctrine\ORM\Tools\Console\Command\SchemaTool\
 	{
 		parent::initialize($input, $output);
 		$this->cacheStorage->clean(array(Nette\Caching\Cache::ALL => TRUE));
-		Nette\Diagnostics\Debugger::$productionMode = FALSE;
+		Debugger::$productionMode = FALSE;
 	}
 
 

--- a/src/Kdyby/Doctrine/Console/SchemaDropCommand.php
+++ b/src/Kdyby/Doctrine/Console/SchemaDropCommand.php
@@ -16,7 +16,12 @@ use Kdyby;
 use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tracy\Debugger;
 
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+}
 
 
 /**
@@ -47,7 +52,7 @@ class SchemaDropCommand extends Doctrine\ORM\Tools\Console\Command\SchemaTool\Dr
 	{
 		parent::initialize($input, $output);
 		$this->cacheStorage->clean(array(Nette\Caching\Cache::ALL => TRUE));
-		Nette\Diagnostics\Debugger::$productionMode = FALSE;
+		Debugger::$productionMode = FALSE;
 	}
 
 

--- a/src/Kdyby/Doctrine/Console/SchemaUpdateCommand.php
+++ b/src/Kdyby/Doctrine/Console/SchemaUpdateCommand.php
@@ -16,7 +16,12 @@ use Kdyby;
 use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tracy\Debugger;
 
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+}
 
 
 /**
@@ -47,7 +52,7 @@ class SchemaUpdateCommand extends Doctrine\ORM\Tools\Console\Command\SchemaTool\
 	{
 		parent::initialize($input, $output);
 		$this->cacheStorage->clean(array(Nette\Caching\Cache::ALL => TRUE));
-		Nette\Diagnostics\Debugger::$productionMode = FALSE;
+		Debugger::$productionMode = FALSE;
 	}
 
 

--- a/src/Kdyby/Doctrine/Console/ValidateSchemaCommand.php
+++ b/src/Kdyby/Doctrine/Console/ValidateSchemaCommand.php
@@ -15,7 +15,12 @@ use Kdyby;
 use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tracy\Debugger;
 
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+}
 
 
 /**
@@ -43,7 +48,7 @@ class ValidateSchemaCommand extends Doctrine\ORM\Tools\Console\Command\ValidateS
 	{
 		parent::initialize($input, $output);
 		$this->cacheStorage->clean(array(Nette\Caching\Cache::ALL => TRUE));
-		Nette\Diagnostics\Debugger::$productionMode = FALSE;
+		Debugger::$productionMode = FALSE;
 	}
 
 }

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -18,7 +18,7 @@ use Nette;
 use Nette\PhpGenerator as Code;
 use Nette\Utils\Strings;
 use Nette\Utils\Validators;
-
+use Tracy\Debugger;
 
 
 if (!class_exists('Nette\DI\CompilerExtension')) {
@@ -30,6 +30,10 @@ if (!class_exists('Nette\DI\CompilerExtension')) {
 if (isset(Nette\Loaders\NetteLoader::getInstance()->renamed['Nette\Configurator']) || !class_exists('Nette\Configurator')) {
 	unset(Nette\Loaders\NetteLoader::getInstance()->renamed['Nette\Configurator']); // fuck you
 	class_alias('Nette\Config\Configurator', 'Nette\Configurator');
+}
+
+if (!class_exists('Tracy\Debugger')) {
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
 }
 
 /**
@@ -517,8 +521,9 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			$init->addBody($line);
 		}
 
-		if (property_exists('Nette\Diagnostics\BlueScreen', 'collapsePaths')) {
-			$blueScreen = 'Nette\Diagnostics\Debugger::' . (method_exists('Nette\Diagnostics\Debugger', 'getBlueScreen') ? 'getBlueScreen()' : '$blueScreen');
+		if (property_exists('Tracy\BlueScreen', 'collapsePaths')) {
+			$blueScreen = (class_exists('Tracy\Debugger') ? 'Tracy\Debugger::' : 'Nette\Diagnostics\Debugger::')
+				. (method_exists('Tracy\Debugger', 'getBlueScreen') ? 'getBlueScreen()' : '$blueScreen');
 			$commonDirname = dirname(Nette\Reflection\ClassType::from('Doctrine\Common\Version')->getFileName());
 
 			$init->addBody($blueScreen . '->collapsePaths[] = ?;', array(dirname(Nette\Reflection\ClassType::from('Kdyby\Doctrine\Exception')->getFileName())));

--- a/src/Kdyby/Doctrine/Diagnostics/Panel.php
+++ b/src/Kdyby/Doctrine/Diagnostics/Panel.php
@@ -16,11 +16,21 @@ use Doctrine\Common\Persistence\Proxy;
 use Doctrine\Common\Annotations\AnnotationException;
 use Kdyby;
 use Nette;
-use Nette\Diagnostics\Bar;
-use Nette\Diagnostics\BlueScreen;
-use Nette\Diagnostics\Debugger;
 use Nette\Utils\Strings;
+use Tracy\Bar;
+use Tracy\BlueScreen;
+use Tracy\Debugger;
+use Tracy\Helpers;
+use Tracy\IBarPanel;
 
+
+if (!class_exists('Tracy\Bar')) {
+	class_alias('Nette\Diagnostics\Bar', 'Tracy\Bar');
+	class_alias('Nette\Diagnostics\BlueScreen', 'Tracy\BlueScreen');
+	class_alias('Nette\Diagnostics\Debugger', 'Tracy\Debugger');
+	class_alias('Nette\Diagnostics\Helpers', 'Tracy\Helpers');
+	class_alias('Nette\Diagnostics\IBarPanel', 'Tracy\IBarPanel');
+}
 
 
 /**
@@ -30,7 +40,7 @@ use Nette\Utils\Strings;
  * @author Patrik Votoček
  * @author Filip Procházka <filip@prochazka.su>
  */
-class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrine\DBAL\Logging\SQLLogger
+class Panel extends Nette\Object implements IBarPanel, Doctrine\DBAL\Logging\SQLLogger
 {
 
 	/**
@@ -163,7 +173,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 
 
 
-	/***************** Nette\Diagnostics\IBarPanel ********************/
+	/***************** Tracy\IBarPanel ********************/
 
 
 
@@ -226,8 +236,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 		$parametrized = static::formatQuery($sql, (array) $params);
 		$s = self::highlightQuery($parametrized);
 		if ($source) {
-			$s .= Nette\Diagnostics\Helpers::editorLink($source[0], $source[1])
-				->setText('.../' . basename(dirname($source[0])) . '/' . basename($source[0]));
+			$s .= Helpers::editorLink($source[0], $source[1]);
 		}
 
 		return '<tr><td>' . sprintf('%0.3f', $time * 1000) . '</td>' .
@@ -311,8 +320,8 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 
 				return array(
 					'tab' => 'Invalid entity',
-					'panel' => '<p><b>File:</b> ' . Nette\Diagnostics\Helpers::editorLink($file, $errorLine) . '</p>' .
-						Nette\Diagnostics\BlueScreen::highlightFile($file, $errorLine),
+					'panel' => '<p><b>File:</b> ' . Helpers::editorLink($file, $errorLine) . '</p>' .
+						BlueScreen::highlightFile($file, $errorLine),
 				);
 			}
 
@@ -337,8 +346,8 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 
 				return array(
 					'tab' => 'Invalid schema',
-					'panel' => '<p><b>File:</b> ' . Nette\Diagnostics\Helpers::editorLink($file, $errorLine) . '</p>' .
-						Nette\Diagnostics\BlueScreen::highlightFile($file, $errorLine),
+					'panel' => '<p><b>File:</b> ' . Helpers::editorLink($file, $errorLine) . '</p>' .
+						BlueScreen::highlightFile($file, $errorLine),
 				);
 			}
 
@@ -362,14 +371,14 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 			if (isset($e->queryString)) {
 				$sql = $e->queryString;
 
-			} elseif ($item = Nette\Diagnostics\Helpers::findTrace($e->getTrace(), 'Doctrine\DBAL\Connection::executeQuery')) {
+			} elseif ($item = Helpers::findTrace($e->getTrace(), 'Doctrine\DBAL\Connection::executeQuery')) {
 				$sql = $item['args'][0];
 				$params = $item['args'][1];
 
-			} elseif ($item = Nette\Diagnostics\Helpers::findTrace($e->getTrace(), 'PDO::query')) {
+			} elseif ($item = Helpers::findTrace($e->getTrace(), 'PDO::query')) {
 				$sql = $item['args'][0];
 
-			} elseif ($item = Nette\Diagnostics\Helpers::findTrace($e->getTrace(), 'PDO::prepare')) {
+			} elseif ($item = Helpers::findTrace($e->getTrace(), 'PDO::prepare')) {
 				$sql = $item['args'][0];
 			}
 
@@ -417,7 +426,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 		$e = NULL;
 		if ($source && is_array($source)) {
 			list($file, $line) = $source;
-			$e = '<p><b>File:</b> ' . Nette\Diagnostics\Helpers::editorLink($file, $line) . '</p>';
+			$e = '<p><b>File:</b> ' . Helpers::editorLink($file, $line) . '</p>';
 		}
 
 		// styles and dump
@@ -563,9 +572,9 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 			return FALSE;
 		}
 
-		$dump = Nette\Diagnostics\BlueScreen::highlightFile($file, $errorLine);
+		$dump = BlueScreen::highlightFile($file, $errorLine);
 
-		return '<p><b>File:</b> ' . Nette\Diagnostics\Helpers::editorLink($file, $errorLine) . '</p>' . $dump;
+		return '<p><b>File:</b> ' . Helpers::editorLink($file, $errorLine) . '</p>' . $dump;
 	}
 
 
@@ -675,7 +684,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 	/**
 	 * Registers panel to debugger
 	 *
-	 * @param \Nette\Diagnostics\Bar $bar
+	 * @param \Tracy\Bar $bar
 	 */
 	public function registerBarPanel(Bar $bar)
 	{
@@ -719,7 +728,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 	 */
 	private static function getDebuggerBar()
 	{
-		return method_exists('Nette\Diagnostics\Debugger', 'getBar') ? Debugger::getBar() : Debugger::$bar;
+		return method_exists('Tracy\Debugger', 'getBar') ? Debugger::getBar() : Debugger::$bar;
 	}
 
 
@@ -729,7 +738,7 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel, Doctrin
 	 */
 	private static function getDebuggerBlueScreen()
 	{
-		return method_exists('Nette\Diagnostics\Debugger', 'getBlueScreen') ? Debugger::getBlueScreen() : Debugger::$blueScreen;
+		return method_exists('Tracy\Debugger', 'getBlueScreen') ? Debugger::getBlueScreen() : Debugger::$blueScreen;
 	}
 
 }


### PR DESCRIPTION
**Tracy** replaces **Nette\Diagnostics**

Note: `Tracy\Helpers::editorLink` no more returns `Html` class, [see here](https://github.com/nette/tracy/blob/6386d3fcbe2a44ecae60c8f92645b43a1aa81821/src/Tracy/Helpers.php#L26-L58)
