### PR TITLE
Allow empty result for IEntityProvider

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -251,7 +251,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		foreach ($this->compiler->getExtensions() as $extension) {
 			if ($extension instanceof IEntityProvider) {
 				$metadata = $extension->getEntityMappings();
-				Validators::assert($metadata, 'array:1..');
+				Validators::assert($metadata, 'array');
 				$config['metadata'] = array_merge($config['metadata'], $metadata);
 			}
 


### PR DESCRIPTION
In hind sight It was unnecessarily restrictive and I actually counting on this behaviour in [rixxi/gedmo](https://github.com/rixxi/gedmo) :smile:.

[Closes  #92]
