### PR TITLE
Created entity identity trait

### DIFF
--- a/src/Kdyby/Doctrine/Entities/Identity.php
+++ b/src/Kdyby/Doctrine/Entities/Identity.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008, 2012 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.md that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+
+
+
+/**
+ * @author Martin Štekl <martin.stekl@gmail.com>
+ *
+ * @property-read int $id
+ */
+trait Identity
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\Column(type="integer")
+	 * @ORM\GeneratedValue
+	 * @var integer
+	 */
+	private $id;
+
+
+
+	/**
+	 * @return integer
+	 */
+	final public function getId()
+	{
+		return $this->id;
+	}
+
+
+
+	public function __clone()
+	{
+		$this->id = NULL;
+	}
+
+}


### PR DESCRIPTION
Since `IdentifiedEntity` is deprecated from good reasons there still could be simple way to define entity with identity. This trait should solve it for projects running on PHP 5.4 or higher.
