### PR TITLE
ReadOnlyCollectionWrapper support for Selectable (via additional class)

### DIFF
--- a/src/Kdyby/Doctrine/Collections/SelectableReadOnlyCollectionWrapper.php
+++ b/src/Kdyby/Doctrine/Collections/SelectableReadOnlyCollectionWrapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Collections;
+
+use Doctrine\Common\Collections\Selectable;
+
+/**
+ * Read-only collection wrapper.
+ * Prohibits any write/modify operations, but allows all non-modifying.
+ * @author Michal Gebauer
+ */
+class SelectableReadOnlyCollectionWrapper extends ReadOnlyCollectionWrapper implements Selectable
+{
+	/** @var Collection */
+	private $inner;
+
+	public function __construct(Collection $collection)
+	{
+		if ( ! $collection instanceof Selectable) {
+			throw new Exception('Collection must implement Doctrine\Common\Collections\Selectable interface.');
+		}
+
+		$this->inner = $collection;
+		parent::__construct($collection);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function matching(Criteria $criteria)
+	{
+		return new static($this->inner->matching($criteria));
+	}
+
+}

--- a/src/Kdyby/Doctrine/Entities/BaseEntity.php
+++ b/src/Kdyby/Doctrine/Entities/BaseEntity.php
@@ -12,9 +12,11 @@ namespace Kdyby\Doctrine\Entities;
 
 use Doctrine;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Mapping as ORM;
 use Kdyby;
 use Kdyby\Doctrine\Collections\ReadOnlyCollectionWrapper;
+use Kdyby\Doctrine\Collections\SelectableReadOnlyCollectionWrapper;
 use Kdyby\Doctrine\MemberAccessException;
 use Kdyby\Doctrine\UnexpectedValueException;
 use Nette;
@@ -333,7 +335,7 @@ abstract class BaseEntity extends Nette\Object implements \Serializable
 	protected function convertCollection($property, array $args)
 	{
 		if (isset($args[0]) && $args[0] === TRUE) {
-			return new ReadOnlyCollectionWrapper($this->$property);
+			return $this->property instanceof Selectable ? new SelectableReadOnlyCollectionWrapper($this->property) : new ReadOnlyCollectionWrapper($this->$property);
 		}
 
 		return $this->$property->toArray();


### PR DESCRIPTION
ReadOnlyCollectionWrapper without Selectable implementation is hard to use in full OOP design.

**No tests, open for discussion.**

Alternatively wrapper can implement Selectable and throw exception when matching used on collection that has not implemented Selectable, but that approach will break code relying on Selectable detection.