### PR TITLE
Created method called after fetch

### DIFF
--- a/src/Kdyby/Doctrine/QueryObject.php
+++ b/src/Kdyby/Doctrine/QueryObject.php
@@ -184,6 +184,19 @@ abstract class QueryObject extends Nette\Object implements Kdyby\Persistence\Que
 
 	/**
 	 * @param \Kdyby\Persistence\Queryable $repository
+	 * @param int|NULL $limit
+	 * @param int|NULL $offset
+	 * @return void
+	 */
+	public function preFetch(Queryable $repository, $limit = NULL, $offset = NULL)
+	{
+
+	}
+
+
+
+	/**
+	 * @param \Kdyby\Persistence\Queryable $repository
 	 * @param \Iterator $iterator
 	 * @return void
 	 */

--- a/src/Kdyby/Doctrine/QueryObject.php
+++ b/src/Kdyby/Doctrine/QueryObject.php
@@ -183,6 +183,18 @@ abstract class QueryObject extends Nette\Object implements Kdyby\Persistence\Que
 
 
 	/**
+	 * @param \Kdyby\Persistence\Queryable $repository
+	 * @param \Iterator $iterator
+	 * @return void
+	 */
+	public function doAfterFetch(Queryable $repository, \Iterator $iterator)
+	{
+
+	}
+
+
+
+	/**
 	 * @internal For Debugging purposes only!
 	 * @return \Doctrine\ORM\Query
 	 */

--- a/src/Kdyby/Doctrine/QueryObject.php
+++ b/src/Kdyby/Doctrine/QueryObject.php
@@ -187,7 +187,7 @@ abstract class QueryObject extends Nette\Object implements Kdyby\Persistence\Que
 	 * @param \Iterator $iterator
 	 * @return void
 	 */
-	public function doAfterFetch(Queryable $repository, \Iterator $iterator)
+	public function postFetch(Queryable $repository, \Iterator $iterator)
 	{
 
 	}

--- a/src/Kdyby/Doctrine/ResultSet.php
+++ b/src/Kdyby/Doctrine/ResultSet.php
@@ -322,6 +322,9 @@ class ResultSet extends Nette\Object implements \Countable, \IteratorAggregate
 			} else {
 				$this->iterator = new \ArrayIterator($this->query->getResult(NULL));
 			}
+			if ($this->queryObject !== NULL && $this->repository !== NULL) {
+				$this->queryObject->doAfterFetch($this->repository, $this->iterator);
+			}
 
 			return $this->iterator;
 

--- a/src/Kdyby/Doctrine/ResultSet.php
+++ b/src/Kdyby/Doctrine/ResultSet.php
@@ -311,6 +311,9 @@ class ResultSet extends Nette\Object implements \Countable, \IteratorAggregate
 		try {
 			$this->query->setHydrationMode($hydrationMode);
 
+			if ($this->queryObject !== NULL && $this->repository !== NULL) {
+				$this->queryObject->preFetch($this->repository, $this->query->getMaxResults(), $this->query->getFirstResult());
+			}
 			if ($this->query->getMaxResults() > 0 || $this->query->getFirstResult() > 0) {
 				if ($this->query instanceof ORM\Query) {
 					$this->iterator = $this->getPaginatedQuery()->getIterator();

--- a/src/Kdyby/Doctrine/ResultSet.php
+++ b/src/Kdyby/Doctrine/ResultSet.php
@@ -323,7 +323,7 @@ class ResultSet extends Nette\Object implements \Countable, \IteratorAggregate
 				$this->iterator = new \ArrayIterator($this->query->getResult(NULL));
 			}
 			if ($this->queryObject !== NULL && $this->repository !== NULL) {
-				$this->queryObject->doAfterFetch($this->repository, $this->iterator);
+				$this->queryObject->postFetch($this->repository, $this->iterator);
 			}
 
 			return $this->iterator;


### PR DESCRIPTION
`preLoad`: It is useful to filter data by complex conditions in relatively simple query and then use it it data loading (main) query.
`postLoad`: It is useful to load some extra relations which could negatively affect performance if it would be included in main query.

It can be used in following way
```php
class ComplexQuery extends QueryObject
{
    private $ids = array();

    protected function doCreateQuery(Queryable $repository)
    {
        // process query which loads only @...ToOne relations
    }

    public function preFetch(Queryable $repository, $limit = NULL, $offset = NULL)
    {
        // process filtering of main entity IDs
        $this->ids = $ids;
    }

    public function postFetch(Queryable $repository, \Iterator $iterator)
    {
        $result = iterator_to_array($iterator, TRUE);
        // process loading of all needed relations in @...ToMany direction
    }
}
```