### PR TITLE
ClassMetadata: Switch to using doctrine/instantiator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 		"nette/robot-loader": "~2.2@dev",
 
 		"doctrine/orm": "~2.4.1",
+		"doctrine/instantiator": "~1.0.2",
 		"kdyby/events": "~2.2@dev",
 		"kdyby/console": "~2.3@dev",
 		"kdyby/annotations": "~2.1@dev",

--- a/src/Kdyby/Doctrine/Mapping/ClassMetadata.php
+++ b/src/Kdyby/Doctrine/Mapping/ClassMetadata.php
@@ -23,11 +23,9 @@ class ClassMetadata extends Doctrine\ORM\Mapping\ClassMetadata
 {
 
 	/**
-	 * The prototype from which new instances of the mapped class are created.
-	 *
-	 * @var object
+	 * @var Doctrine\Instantiator\InstantiatorInterface|NULL
 	 */
-	private $_prototype;
+	private $instantiator;
 
 
 
@@ -50,23 +48,11 @@ class ClassMetadata extends Doctrine\ORM\Mapping\ClassMetadata
 	 */
 	public function newInstance()
 	{
-		if ($this->_prototype === null) {
-			if (PHP_VERSION_ID === 50429 || PHP_VERSION_ID === 50513 || PHP_VERSION_ID === 50600) {
-				if ($this->getReflectionClass()->implementsInterface('Serializable')) {
-					$this->_prototype = @unserialize(sprintf('C:%d:"%s":0:{}', strlen($this->name), $this->name));
-				}
-			}
-
-			if (!$this->_prototype) {
-				$this->_prototype = @unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
-			}
-
-			if (!$this->_prototype) {
-				throw new Kdyby\Doctrine\UnexpectedValueException("Prototype of class {$this->name} cannot be created, probably due to some PHP bug.");
-			}
+		if ($this->instantiator === NULL) {
+			$this->instantiator = new Doctrine\Instantiator\Instantiator();
 		}
 
-		return clone $this->_prototype;
+		return $this->instantiator->instantiate($this->name);
 	}
 
 }

--- a/tests/composer-nette-2.2.json
+++ b/tests/composer-nette-2.2.json
@@ -22,6 +22,7 @@
 		"nette/utils": "2.2.*",
 
 		"doctrine/orm": "~2.4.1",
+		"doctrine/instantiator": "~1.0.2",
 		"kdyby/events": "~2.2@dev",
 		"kdyby/console": "~2.3@dev",
 		"kdyby/annotations": "~2.1@dev",


### PR DESCRIPTION
Not using DI as it breaks constructor signature and does not work with serializability anyway.
(Not tested locally, lets trust CI. :smile:  )

[Fixes #128]
