### PR TITLE
Better error message when extension is not properly configured

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -139,6 +139,11 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 			$config = array_diff_key($config, $defaults);
 		}
+		
+		if (empty($config)) {
+			throw new Kdyby\Doctrine\UnexpectedValueException("Please configure the Doctrine extensions using the section '{$this->name}:' in your config file.");
+		}
+		
 
 		foreach ($config as $name => $emConfig) {
 			if (!is_array($emConfig)) {


### PR DESCRIPTION
Happens since version 2.1.

If you don't properly configure database connection (or have same sample configuration as are defaults in extension), DI compilation produces very weird and missleading error 

```
Nette\DI\ServiceCreationException

Service '...': Reference to missing service of type Kdyby\Doctrine\EntityManager.
```

this happens because EM is not registred by extension, because `$config` in [here](https://github.com/Kdyby/Doctrine/blob/master/src/Kdyby/Doctrine/DI/OrmExtension.php#L143) is empty.

It was introduced by this commit https://github.com/Kdyby/Doctrine/commit/c9450ab6a8c94f112a57f93d20df35f695669b06
