### PR TITLE
Missing parentheses cause wrong error message

### DIFF
--- a/src/Kdyby/Doctrine/QueryObject.php
+++ b/src/Kdyby/Doctrine/QueryObject.php
@@ -212,7 +212,7 @@ abstract class QueryObject extends Nette\Object implements Kdyby\Persistence\Que
 			throw new UnexpectedValueException(
 				"Method " . $this->getReflection()->getMethod('doCreateQuery') . " must return " .
 				"instanceof Doctrine\\ORM\\Query or Kdyby\\Doctrine\\QueryBuilder or Kdyby\\Doctrine\\DqlSelection, " .
-				is_object($query) ? 'instance of ' . get_class($query) : gettype($query) . " given."
+				(is_object($query) ? 'instance of ' . get_class($query) : gettype($query)) . " given."
 			);
 		}
 


### PR DESCRIPTION
![snimek obrazovky porizeny 2014-10-25 14 11 02](https://cloud.githubusercontent.com/assets/5060034/4779680/0821c6ec-5c40-11e4-953c-999d2aef4f9a.png)
Without them it produces message like "instance of Foo\Bar\Class".
