### PR TITLE
Fixed BC break when extension name contains a dot

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -215,8 +215,8 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			->setClass('Kdyby\Doctrine\Registry', array(
 				$this->configuredConnections,
 				$this->configuredManagers,
-				$builder->expand('%' . $this->prefix('dbal.defaultConnection') . '%'),
-				$builder->expand('%' . $this->prefix('orm.defaultEntityManager') . '%'),
+				$builder->parameters[$this->name]['dbal']['defaultConnection'],
+				$builder->parameters[$this->name]['orm']['defaultEntityManager'],
 			));
 	}
 

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -67,10 +67,10 @@ class ExtensionTest extends Tester\TestCase
 		/** @var Kdyby\Doctrine\EntityManager $default */
 		$default = $container->getByType('Kdyby\Doctrine\EntityManager');
 		Assert::true($default instanceof Kdyby\Doctrine\EntityManager);
-		Assert::same($container->getService('doctrine.default.entityManager'), $default);
+		Assert::same($container->getService('kdyby.doctrine.default.entityManager'), $default);
 
-		Assert::true($container->getService('doctrine.remote.entityManager') instanceof Kdyby\Doctrine\EntityManager);
-		Assert::notSame($container->getService('doctrine.remote.entityManager'), $default);
+		Assert::true($container->getService('kdyby.doctrine.remote.entityManager') instanceof Kdyby\Doctrine\EntityManager);
+		Assert::notSame($container->getService('kdyby.doctrine.remote.entityManager'), $default);
 	}
 
 

--- a/tests/KdybyTests/Doctrine/config/memory.neon
+++ b/tests/KdybyTests/Doctrine/config/memory.neon
@@ -1,4 +1,4 @@
-doctrine:
+kdyby.doctrine:
 	driver: pdo_sqlite
 	memory: true
 	metadata:

--- a/tests/KdybyTests/Doctrine/config/multiple-connections.neon
+++ b/tests/KdybyTests/Doctrine/config/multiple-connections.neon
@@ -1,4 +1,4 @@
-doctrine:
+kdyby.doctrine:
 	metadata:
 		KdybyTests\Doctrine: annotations(%appDir%/KdybyTests/Doctrine/models)
 

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -6,10 +6,10 @@ extensions:
 	events: Kdyby\Events\DI\EventsExtension
 	console: Kdyby\Console\DI\ConsoleExtension
 	annotations: Kdyby\Annotations\DI\AnnotationsExtension
-	doctrine: Kdyby\Doctrine\DI\OrmExtension
+	kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
 
 
-doctrine:
+kdyby.doctrine:
 	metadataCache: array
 	queryCache: array
 	resultCache: array


### PR DESCRIPTION
I use so many extensions that I want to namespace them:

```
extensions:
    kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
```

Worked fine with Kdyby/Doctrine 2.1, but doesn't work with 2.2.0.

The exception:

```
Nette\InvalidArgumentException: Missing parameter 'kdyby.doctrine.dbal.defaultConnection'.
(previous) Nette\InvalidArgumentException: Missing item 'kdyby'.
```
