### PR TITLE
Identifier trait: set IDENTITY strategy of GeneratedValue annotation

### DIFF
--- a/src/Kdyby/Doctrine/Entities/Attributes/Identifier.php
+++ b/src/Kdyby/Doctrine/Entities/Attributes/Identifier.php
@@ -25,7 +25,7 @@ trait Identifier
 	/**
 	 * @ORM\Id
 	 * @ORM\Column(type="integer")
-	 * @ORM\GeneratedValue
+	 * @ORM\GeneratedValue(strategy="IDENTITY")
 	 * @var integer
 	 */
 	private $id;


### PR DESCRIPTION
Schema tool does not add `AUTO_INCREMENT` in SQL. Setting up strategy to `IDENTITY` fixes it.