### PR TITLE
Removed final from Identifier::getId()

### DIFF
--- a/src/Kdyby/Doctrine/Entities/Attributes/Identifier.php
+++ b/src/Kdyby/Doctrine/Entities/Attributes/Identifier.php
@@ -35,7 +35,7 @@ trait Identifier
 	/**
 	 * @return integer
 	 */
-	final public function getId()
+	public function getId()
 	{
 		return $this->id;
 	}


### PR DESCRIPTION
I've found [this topic](https://help.kdyby.org/question/?questionId=441) on Kdyby forum and noticed something. I'm not sure when it chaged but Doctine now generates this code for non-final getId method:

```php
    /**
     * {@inheritDoc}
     */
    public function getId()
    {
        if ($this->__isInitialized__ === false) {
            return (int)  parent::getId();
        }
 
 
        $this->__initializer__ && $this->__initializer__->__invoke($this, 'getId', array());
 
        return parent::getId();
    }
```

It should be ok to remove the final if doctrine behaves this way, right?