### PR TITLE
Fixed generating sql value for POINT and LINE_STRING type

### DIFF
--- a/src/Kdyby/Doctrine/Geo/Element.php
+++ b/src/Kdyby/Doctrine/Geo/Element.php
@@ -222,7 +222,12 @@ class Element extends Nette\Object
 			$this->init();
 		}
 
-		return strtoupper($this->name) . '((' . implode($this->separator, $this->coordinates) . '))';
+		$coordinates = implode($this->separator, $this->coordinates);
+		if (in_array($this->name, array(self::POINT, self::LINE_STRING))) {
+			return strtoupper($this->name) . '(' . $coordinates . ')';
+		} else {
+			return strtoupper($this->name) . '((' . $coordinates . '))';
+		}
 	}
 
 
@@ -233,7 +238,7 @@ class Element extends Nette\Object
 		$coordsSeparator = $this->coordsSeparator;
 		$coordsRegexp = '[\d\.]+\s*' . preg_quote($coordsSeparator) . '\s*[\d\.]+';
 		$coordsListRegexp = '(?P<coords>(?:' . $coordsRegexp . ')(?:\s*' . preg_quote($separator) . '\s*' . $coordsRegexp . ')*)';
-		if (!$m = Strings::match($this->stringValue, '~^(?P<name>\w+)\(\(' . $coordsListRegexp . '\)\)$~i')) {
+		if (!$m = Strings::match($this->stringValue, '~^(?P<name>\w+)\(\(?' . $coordsListRegexp . '\)?\)$~i')) {
 			throw new Kdyby\Doctrine\InvalidArgumentException("Given expression '" . $this->stringValue . "' is not geometry definition.");
 		}
 

--- a/tests/KdybyTests/Doctrine/Diagnostics/SimpleParameterFormatter.phpt
+++ b/tests/KdybyTests/Doctrine/Diagnostics/SimpleParameterFormatter.phpt
@@ -86,7 +86,7 @@ class SimpleParameterFormatterTest extends Tester\TestCase
 	{
 		$element = new Element();
 		$element->addCoordinate(14.000000, 51.000000);
-		Assert::same('"POINT((51.0000000000000 14.0000000000000))"', SimpleParameterFormatter::format($element));
+		Assert::same('"POINT(51.0000000000000 14.0000000000000)"', SimpleParameterFormatter::format($element));
 	}
 
 

--- a/tests/KdybyTests/Doctrine/GeoElement.phpt
+++ b/tests/KdybyTests/Doctrine/GeoElement.phpt
@@ -30,14 +30,14 @@ class GeoElementTest extends Tester\TestCase
 	{
 		return array(
 			array(
-				'POINT((1 2))',
+				'POINT(1 2)',
 				$this->stubElement('POINT', array(array(1.0, 2.0))),
-				'POINT((1.0000000000000 2.0000000000000))'
+				'POINT(1.0000000000000 2.0000000000000)'
 			),
 			array(
-				'LINESTRING((1 2,3 4))',
+				'LINESTRING(1 2,3 4)',
 				$this->stubElement('LINESTRING', array(array(1.0, 2.0), array(3.0, 4.0))),
-				'LINESTRING((1.0000000000000 2.0000000000000,3.0000000000000 4.0000000000000))',
+				'LINESTRING(1.0000000000000 2.0000000000000,3.0000000000000 4.0000000000000)',
 			),
 			array(
 				"POLYGON((1.0000000000000  2.0000000000000, 3.0000000000000 \t4.0000000000000))",

--- a/tests/KdybyTests/Doctrine/GeometryType.phpt
+++ b/tests/KdybyTests/Doctrine/GeometryType.phpt
@@ -83,7 +83,7 @@ class GeometryTypeTest extends Tester\TestCase
 		$point->addCoordinate(1, 2);
 
 		$sql = $this->polygon->convertToDatabaseValue($point, new MySqlPlatform());
-		Assert::same('POINT((2.0000000000000 1.0000000000000))', $sql);
+		Assert::same('POINT(2.0000000000000 1.0000000000000)', $sql);
 	}
 
 }


### PR DESCRIPTION
POINT and LINESTRING types requires only single brackets.

http://dev.mysql.com/doc/refman/4.1/en/point-property-functions.html
http://dev.mysql.com/doc/refman/4.1/en/linestring-property-functions.html