### PR TITLE
travis: PHP 7.0 nightly added, make test suite lighter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: php
 
-env:
-  - NETTE=nette-2.3-dev
-  - NETTE=nette-2.3
-  - NETTE=nette-2.2
-
 php:
   - 5.3.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
   - hhvm-nightly
 
 matrix:
   allow_failures:
+    - php: 7.0
     - php: hhvm
     - php: hhvm-nightly
+  include:
+    - php: 5.6
+      env: NETTE=nette-2.2
 
 before_install:
   - composer self-update
@@ -25,16 +25,13 @@ install:
   - mkdir -p vendor/bin
   - wget -O vendor/bin/composer-nette https://raw.githubusercontent.com/Kdyby/TesterExtras/master/bin/composer-nette.php
   - php vendor/bin/composer-nette
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
 
 before_script:
-  - composer create-project --prefer-source --dev --no-interaction jakub-onderka/php-parallel-lint vendor/php-parallel-lint ~0.8
-  - php vendor/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
-  - composer create-project --prefer-source --dev --no-interaction nette/code-checker vendor/code-checker ~2.2
-  - php vendor/code-checker/src/code-checker.php -d src
-  - php vendor/code-checker/src/code-checker.php -d tests
+  - travis/static_analysis.sh
 
-script: vendor/bin/tester -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
+script:
+  - vendor/bin/tester -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
 
 after_failure:
   - 'for i in $(find ./tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done'

--- a/travis/static_analysis.sh
+++ b/travis/static_analysis.sh
@@ -1,0 +1,7 @@
+if [ $TRAVIS_PHP_VERSION = '5.6' ]; then
+  composer create-project --prefer-source --dev --no-interaction jakub-onderka/php-parallel-lint vendor/php-parallel-lint ~0.8
+  php vendor/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
+  composer create-project --prefer-source --dev --no-interaction nette/code-checker vendor/code-checker ~2.2
+  php vendor/code-checker/src/code-checker.php -d src
+  php vendor/code-checker/src/code-checker.php -d tests
+fi


### PR DESCRIPTION
- Run tests for misc Nette versions, but not cross all PHP versions => only duplicates Nette tests matrix. Inspired: https://github.com/Behat/MinkExtension/commit/8a2e12023baf04a67c1abc056975cc90094ab09f

- `--dev` is by default for couple of months

- Also there is only 5 concurrent jobs per Github user, so this should make all faster. 22 jobs => 
8 jobs with pretty much same effort.

- Static analysis should be run just once (e.g. for PHP 5.6):

```sh
before_script:
  - composer create-project --prefer-source --dev --no-interaction jakub-onderka/php-parallel-lint vendor/php-parallel-lint ~0.8
  - php vendor/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
  - composer create-project --prefer-source --dev --no-interaction nette/code-checker vendor/code-checker ~2.2
  - php vendor/code-checker/src/code-checker.php -d src
  - php vendor/code-checker/src/code-checker.php -d tests
```