### PR TITLE
prevent alias generating as a SQL keyword (not complete keyword list)

### DIFF
--- a/src/Kdyby/Doctrine/QueryBuilder.php
+++ b/src/Kdyby/Doctrine/QueryBuilder.php
@@ -236,16 +236,25 @@ class QueryBuilder extends Doctrine\ORM\QueryBuilder implements \IteratorAggrega
 
 			$aliasLength = 1;
 			do {
-				$joinAs = substr($property, 0, $aliasLength++);
+				$joinAs = $this->buildJoinAs($property, $aliasLength);
 			} while (isset($this->criteriaJoins[$joinAs]));
 			$this->criteriaJoins[$joinAs] = array();
-
 			$this->innerJoin("$alias.$property", $joinAs);
 			$this->criteriaJoins[$alias][$property] = $joinAs;
 			$alias = $joinAs;
 		}
 
 		return $alias;
+	}
+
+	private function buildJoinAs($property, &$aliasLength){
+		$keywords = ['or'];
+		$joinAs = substr($property, 0, $aliasLength);
+		$aliasLength++;
+		if(in_array($joinAs,$keywords)){
+			$joinAs = $this->buildJoinAs($property,$aliasLength);
+		}
+		return $joinAs;
 	}
 
 


### PR DESCRIPTION
I had problem when generating alias from two similar properties, eg. `order` and `order2`. First alias generated was `o` and second was `or` which was causing problems as it's reserved SQL keyword. I've added a function that checks whether alias is in `keywords` list and if it, it adds one more letter, so `or` becomes `ord` instead.

Not sure if correct solution, it seems to work though.