### PR TITLE
EntityRepository: fetch with different hydration mode

### DIFF
--- a/src/Kdyby/Doctrine/EntityRepository.php
+++ b/src/Kdyby/Doctrine/EntityRepository.php
@@ -245,13 +245,14 @@ class EntityRepository extends Doctrine\ORM\EntityRepository implements Persiste
 
 	/**
 	 * @param \Kdyby\Persistence\Query|\Kdyby\Doctrine\QueryObject $queryObject
+	 * @param int $hydrationMode
 	 * @throws QueryException
 	 * @return array|\Kdyby\Doctrine\ResultSet
 	 */
-	public function fetch(Persistence\Query $queryObject)
+	public function fetch(Persistence\Query $queryObject, $hydrationMode = AbstractQuery::HYDRATE_OBJECT)
 	{
 		try {
-			return $queryObject->fetch($this);
+			return $queryObject->fetch($this, $hydrationMode);
 
 		} catch (\Exception $e) {
 			throw $this->handleQueryException($e, $queryObject);


### PR DESCRIPTION
I have a query that results in a single scalar. So I need either to add this parameter to the fetch method, or a new method fetchSingleScalar. Not sure which solution would be better, at this moment I favor this one. What do you think?