### PR TITLE
BaseEntity: return read-only Collection instead of array [RFC]

### DIFF
--- a/src/Kdyby/Doctrine/Entities/BaseEntity.php
+++ b/src/Kdyby/Doctrine/Entities/BaseEntity.php
@@ -89,7 +89,8 @@ abstract class BaseEntity extends Nette\Object implements \Serializable
 
 			} elseif ($op === 'get' && isset($properties[$prop])) {
 				if ($this->$prop instanceof Collection) {
-					return $this->convertCollection($prop, $args);
+					return new ReadOnlyCollectionWrapper($this->$prop);
+
 				} else {
 					return $this->$prop;
 				}
@@ -238,7 +239,7 @@ abstract class BaseEntity extends Nette\Object implements \Serializable
 		$properties = $this->listObjectProperties();
 		if (isset($properties[$name = func_get_arg(0)])) {
 			if ($this->$name instanceof Collection) {
-				$coll = $this->$name->toArray();
+				$coll = new ReadOnlyCollectionWrapper($this->$name);
 
 				return $coll;
 
@@ -321,22 +322,6 @@ abstract class BaseEntity extends Nette\Object implements \Serializable
 		$name[0] = $name[0] & "\xDF";
 
 		return isset($methods['get' . $name]) || isset($methods['is' . $name]);
-	}
-
-
-
-	/**
-	 * @param string $property property name
-	 * @param array $args
-	 * @return Collection|array
-	 */
-	protected function convertCollection($property, array $args)
-	{
-		if (isset($args[0]) && $args[0] === TRUE) {
-			return new ReadOnlyCollectionWrapper($this->$property);
-		}
-
-		return $this->$property->toArray();
 	}
 
 

--- a/tests/KdybyTests/Doctrine/BaseEntity.phpt
+++ b/tests/KdybyTests/Doctrine/BaseEntity.phpt
@@ -92,7 +92,14 @@ class BaseEntityTest extends Tester\TestCase
 	public function testGetProtectedCollection()
 	{
 		$entity = new ConcreteEntity();
+
 		Assert::equal($entity->twos, $entity->getTwos());
+		Assert::type('Kdyby\Doctrine\Collections\ReadOnlyCollectionWrapper', $entity->twos);
+		Assert::type('Kdyby\Doctrine\Collections\ReadOnlyCollectionWrapper', $entity->getTwos());
+
+		Assert::equal($entity->proxies, $entity->getProxies());
+		Assert::type('Kdyby\Doctrine\Collections\ReadOnlyCollectionWrapper', $entity->proxies);
+		Assert::type('Kdyby\Doctrine\Collections\ReadOnlyCollectionWrapper', $entity->getProxies());
 	}
 
 
@@ -234,8 +241,8 @@ class BaseEntityTest extends Tester\TestCase
 	public function testCallGetterOnProtectedCollection()
 	{
 		$entity = new ConcreteEntity();
-		Assert::equal(array((object) array('id' => 2)), $entity->getTwos());
-		Assert::equal(array((object) array('id' => 3)), $entity->getProxies());
+		Assert::equal(array((object) array('id' => 2)), $entity->getTwos()->toArray());
+		Assert::equal(array((object) array('id' => 3)), $entity->getProxies()->toArray());
 	}
 
 
@@ -274,12 +281,12 @@ class BaseEntityTest extends Tester\TestCase
 	{
 		$entity = new ConcreteEntity();
 		$entity->addTwo($a = (object) array('id' => 2));
-		Assert::true((bool) array_filter($entity->getTwos(), function ($two) use ($a) {
+		Assert::truthy($entity->getTwos()->filter(function ($two) use ($a) {
 			return $two === $a;
 		}));
 
 		$entity->addProxy($b = (object) array('id' => 3));
-		Assert::true((bool) array_filter($entity->getProxies(), function ($two) use ($b) {
+		Assert::truthy((bool) $entity->getProxies()->filter(function ($two) use ($b) {
 			return $two === $b;
 		}));
 	}
@@ -313,12 +320,12 @@ class BaseEntityTest extends Tester\TestCase
 		Assert::false($entity->hasProxy((object) array('id' => 3)));
 
 		$twos = $entity->getTwos();
-		Assert::true(!empty($twos));
-		Assert::true($entity->hasTwo(reset($twos)));
+		Assert::false($twos->isEmpty());
+		Assert::true($entity->hasTwo($twos->first()));
 
 		$proxies = $entity->getProxies();
-		Assert::true(!empty($proxies));
-		Assert::true($entity->hasProxy(reset($proxies)));
+		Assert::false($proxies->isEmpty());
+		Assert::true($entity->hasProxy($proxies->first()));
 	}
 
 
@@ -347,16 +354,16 @@ class BaseEntityTest extends Tester\TestCase
 	{
 		$entity = new ConcreteEntity();
 		$twos = $entity->getTwos();
-		Assert::true(!empty($twos));
-		$entity->removeTwo(reset($twos));
+		Assert::false($twos->isEmpty());
+		$entity->removeTwo($twos->first());
 		$twos = $entity->getTwos();
-		Assert::true(empty($twos));
+		Assert::true($twos->isEmpty());
 
 		$proxies = $entity->getProxies();
-		Assert::true(!empty($proxies));
-		$entity->removeProxy(reset($proxies));
+		Assert::false($proxies->isEmpty());
+		$entity->removeProxy($proxies->first());
 		$proxies = $entity->getProxies();
-		Assert::true(empty($proxies));
+		Assert::true($proxies->isEmpty());
 	}
 
 
@@ -382,17 +389,16 @@ class BaseEntityTest extends Tester\TestCase
 
 /**
  * @author Filip Procházka <filip@prochazka.su>
- *
  * @method setTwo()
  * @method addTwo()
  * @method getTwo()
  * @method removeTwo()
  * @method hasTwo()
- * @method getTwos()
+ * @method \Doctrine\Common\Collections\ArrayCollection getTwos()
  * @method addProxy()
  * @method hasProxy()
  * @method removeProxy()
- * @method getProxies()
+ * @method \Doctrine\Common\Collections\ArrayCollection getProxies()
  */
 class ConcreteEntity extends BaseEntity
 {


### PR DESCRIPTION
**This is a BC Break.**

A pretty nasty one too. If you don't have extensive tests, you'll have to go through your entire app manually and fix the usage.

Please comment under this pullrequest, twitter responses will not be taken into consideration.

## Now

Every entity that extends `BaseEntity` get's magic methods. Those magic methods include accessors for collections. 

```php
class Article extends BaseEntity {
    protected $comments;
    public function __construct() {
        $this->comments = new ArrayCollection();
    }
}
```

In the end, you should really write your own accessors and use theese only for prototyping, but this is what you get:

```php
$article = new Article();
$article->addComment(new Comment());
$article->hasComment(new Comment());
$article->removeComment(new Comment());
$article->getComments(); // returns Comment[]
```

> Why does the `getComments` returns array if the property contains Collection, wtf?

It's because that when you expose the raw collection outside of the entity, anybody can do whatever to that collection => entity would no longer be responsible for it's internal state, which is bad.

You can easily change this by writing your own getter.

```php
public function getComments()
{
    return $this->comments;
}
```

You've just did a horrible murder of basket of kittens, but that's problem of your conscience, not mine.

You also can use already present class `ReadOnlyCollectionWrapper`, which is exactly what the name tells. It wraps the collection so you can expose it for reading purposes, but it won't allow anybody to modify it.

```php
public function getComments()
{
    return new ReadOnlyCollectionWrapper($this->comments);
}
```

There you go, much better.

## With this PR

The point of this PR is to not to return the array by default, but `ReadOnlyCollectionWrapper` by default. So you always have a collection and can easily read the relation entities.

## Solving BC

There has been a proposal for option in config to disable this. Which is a good idea and I would love to do that. But the question is **how?**

### Option a)

Considering that entities should behave consistently whether or not they're connected to the EntityManager (proxies, new objects) this would have to be implemented as static property.

### Option b)

Extract the entities namespace out of the package completely and tag two mainlines. The old one with arrays getters, the new one with collection getters. Kdyby/Doctrine would depend on the package, but it would not say on which version. You could easily fallback to the older one just by specifying it in `composer.json`.

### Option c)

Soft-deprecate BaseEntity and create a trait with identical behaviour, but that returns the collection.