### PR TITLE
RepositoryFactory: implemented handling of repositories as services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,11 @@
 			"src/Kdyby/Doctrine/exceptions.php"
 		]
 	},
+	"autoload-dev": {
+		"classmap": [
+			"tests/KdybyTests/Doctrine"
+		]
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "3.0-dev"

--- a/src/Kdyby/Doctrine/DI/IRepositoryFactory.php
+++ b/src/Kdyby/Doctrine/DI/IRepositoryFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\DI;
+
+use Doctrine\ORM;
+use Doctrine\ORM\EntityRepository;
+use Kdyby;
+use Nette;
+
+
+
+/**
+ * @author Filip Procházka <filip@prochazka.su>
+ */
+interface IRepositoryFactory
+{
+
+	/**
+	 * @param ORM\EntityManagerInterface $entityManager
+	 * @param ORM\Mapping\ClassMetadata $classMetadata
+	 * @return EntityRepository
+	 */
+	public function create(ORM\EntityManagerInterface $entityManager, ORM\Mapping\ClassMetadata $classMetadata);
+
+}

--- a/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
+++ b/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\RepositoryFactory.
+ *
+ * @testCase Kdyby\Doctrine\RepositoryFactoryTest
+ * @author Filip Procházka <filip@prochazka.su>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Kdyby;
+use Nette;
+use Tester;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+
+
+/**
+ * @author Filip Procházka <filip@prochazka.su>
+ */
+class RepositoryFactoryTest extends Tester\TestCase
+{
+
+	/**
+	 * @param string $configFile
+	 * @return \SystemContainer|Nette\DI\Container
+	 */
+	public function createContainer($configFile)
+	{
+		require_once __DIR__ . '/models/cms.php';
+
+		$config = new Nette\Configurator();
+		$config->setTempDirectory(TEMP_DIR);
+		$config->addParameters(array('appDir' => $rootDir = __DIR__ . '/..', 'wwwDir' => $rootDir));
+		$config->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+		$config->addConfig(__DIR__ . '/config/' . $configFile . '.neon');
+
+		return $config->createContainer();
+	}
+
+
+
+	public function testCustomRepositoryFactory()
+	{
+		if (!method_exists('Nette\DI\ContainerBuilder', 'findByType')) {
+			Tester\Environment::skip('Custom repositories require functionality that is available only in Nette ~2.3');
+		}
+
+		$container = $this->createContainer('repository-factory');
+
+		/** @var \KdybyTests\Doctrine\CmsAddressRepository $cmsAddressRepository */
+		$cmsAddressRepository = $container->getByType('KdybyTests\Doctrine\CmsAddressRepository');
+		Assert::type('KdybyTests\Doctrine\CmsAddressRepository', $cmsAddressRepository);
+		Assert::type('Kdyby\Doctrine\EntityRepository', $cmsAddressRepository);
+		Assert::same('KdybyTests\Doctrine\CmsAddress', $cmsAddressRepository->getClassName());
+		Assert::same('KdybyTests\Doctrine\CmsAddress', $cmsAddressRepository->getClassMetadata()->getName());
+
+		/** @var \Kdyby\Doctrine\EntityManager $em */
+		$em = $container->getByType('Kdyby\Doctrine\EntityManager');
+		Assert::same($cmsAddressRepository, $em->getRepository('KdybyTests\Doctrine\CmsAddress'));
+	}
+
+
+
+	public function testDefaultRepositoryFactory()
+	{
+		$container = $this->createContainer('repository-factory.default-class');
+
+		/** @var \Kdyby\Doctrine\EntityManager $em */
+		$em = $container->getByType('Kdyby\Doctrine\EntityManager');
+
+		$cmsEmailRepository = $em->getRepository('KdybyTests\Doctrine\CmsEmail');
+		Assert::same('Kdyby\Doctrine\EntityRepository', get_class($cmsEmailRepository));
+		Assert::same('KdybyTests\Doctrine\CmsEmail', $cmsEmailRepository->getClassName());
+		Assert::same('KdybyTests\Doctrine\CmsEmail', $cmsEmailRepository->getClassMetadata()->getName());
+	}
+
+
+
+	public function testCustomRepository_withoutService()
+	{
+		$container = $this->createContainer('repository-factory.without-service');
+
+		/** @var \Kdyby\Doctrine\EntityManager $em */
+		$em = $container->getByType('Kdyby\Doctrine\EntityManager');
+
+		$cmsCommentRepository = $em->getRepository('KdybyTests\Doctrine\CmsComment');
+		Assert::type('KdybyTests\Doctrine\CmsCommentRepository', $cmsCommentRepository);
+		Assert::type('Kdyby\Doctrine\EntityRepository', $cmsCommentRepository);
+		Assert::same('KdybyTests\Doctrine\CmsComment', $cmsCommentRepository->getClassName());
+		Assert::same('KdybyTests\Doctrine\CmsComment', $cmsCommentRepository->getClassMetadata()->getName());
+	}
+
+
+
+	public function testManualRegistration()
+	{
+		$container = $this->createContainer('repository-factory.manual');
+
+		list($employeeRepositoryServiceName) = $container->findByType('KdybyTests\Doctrine\CmsEmployeeRepository');
+
+		/** @var \Kdyby\Doctrine\EntityManager $em */
+		$em = $container->getByType('Kdyby\Doctrine\EntityManager');
+
+		$cmsEmployeeRepository = $em->getRepository('KdybyTests\Doctrine\CmsEmployee');
+		Assert::type('Kdyby\Doctrine\EntityRepository', $cmsEmployeeRepository);
+		Assert::type('KdybyTests\Doctrine\CmsEmployeeRepository', $cmsEmployeeRepository);
+		Assert::same('KdybyTests\Doctrine\CmsEmployee', $cmsEmployeeRepository->getClassName());
+		Assert::same('KdybyTests\Doctrine\CmsEmployee', $cmsEmployeeRepository->getClassMetadata()->getName());
+
+		Assert::false($container->isCreated($employeeRepositoryServiceName));
+		Assert::same($cmsEmployeeRepository, $container->getService($employeeRepositoryServiceName));
+		Assert::same($cmsEmployeeRepository, $container->getByType('KdybyTests\Doctrine\CmsEmployeeRepository'));
+	}
+
+}
+
+\run(new RepositoryFactoryTest());

--- a/tests/KdybyTests/Doctrine/config/repository-factory.default-class.neon
+++ b/tests/KdybyTests/Doctrine/config/repository-factory.default-class.neon
@@ -1,0 +1,6 @@
+kdyby.doctrine:
+	driver: pdo_sqlite
+	memory: true
+	metadata:
+		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
+	defaultRepositoryClassName: Kdyby\Doctrine\EntityRepository

--- a/tests/KdybyTests/Doctrine/config/repository-factory.manual.neon
+++ b/tests/KdybyTests/Doctrine/config/repository-factory.manual.neon
@@ -1,0 +1,16 @@
+kdyby.doctrine:
+	driver: pdo_sqlite
+	memory: true
+	metadata:
+		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
+	defaultRepositoryClassName: Kdyby\Doctrine\EntityRepository
+
+
+services:
+	-
+		class: KdybyTests\Doctrine\CmsEmployeeRepository
+		factory: @Kdyby\Doctrine\EntityManager::getRepository(KdybyTests\Doctrine\CmsEmployee)
+
+	-
+		class: KdybyTests\Doctrine\CmsGroupRepository
+		factory: @Kdyby\Doctrine\EntityManager::getDao(KdybyTests\Doctrine\CmsGroup)

--- a/tests/KdybyTests/Doctrine/config/repository-factory.neon
+++ b/tests/KdybyTests/Doctrine/config/repository-factory.neon
@@ -1,0 +1,19 @@
+kdyby.doctrine:
+	driver: pdo_sqlite
+	memory: true
+	metadata:
+		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
+	defaultRepositoryClassName: Kdyby\Doctrine\EntityRepository
+
+
+services:
+	- KdybyTests\Doctrine\CmsAddressRepository
+	- KdybyTests\Doctrine\CmsArticleRepository
+
+	-
+		class: KdybyTests\Doctrine\CmsEmployeeRepository
+		factory: @Kdyby\Doctrine\EntityManager::getRepository(KdybyTests\Doctrine\CmsEmployee)
+
+	-
+		class: KdybyTests\Doctrine\CmsGroupRepository
+		factory: @Kdyby\Doctrine\EntityManager::getDao(KdybyTests\Doctrine\CmsGroup)

--- a/tests/KdybyTests/Doctrine/config/repository-factory.without-service.neon
+++ b/tests/KdybyTests/Doctrine/config/repository-factory.without-service.neon
@@ -1,0 +1,6 @@
+kdyby.doctrine:
+	driver: pdo_sqlite
+	memory: true
+	metadata:
+		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
+	defaultRepositoryClassName: Kdyby\Doctrine\EntityRepository

--- a/tests/KdybyTests/Doctrine/models/cms.php
+++ b/tests/KdybyTests/Doctrine/models/cms.php
@@ -25,7 +25,7 @@ interface ICmsAddress
  * CmsAddress
  *
  * @author Roman S. Borschel
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="\KdybyTests\Doctrine\CmsAddressRepository")
  * @ORM\Table(name="cms_addresses")
  */
 class CmsAddress implements ICmsAddress
@@ -85,7 +85,7 @@ class CmsAddress implements ICmsAddress
 
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="\KdybyTests\Doctrine\CmsArticleRepository")
  * @ORM\Table(name="cms_articles")
  */
 class CmsArticle
@@ -144,7 +144,7 @@ class CmsArticle
 
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="\KdybyTests\Doctrine\CmsCommentRepository")
  * @ORM\Table(name="cms_comments")
  */
 class CmsComment
@@ -184,7 +184,7 @@ class CmsComment
 /**
  * CmsEmail
  *
- * @ORM\Entity
+ * @ORM\Entity()
  * @ORM\Table(name="cms_emails")
  */
 class CmsEmail
@@ -215,7 +215,7 @@ class CmsEmail
  * Description of CmsEmployee
  *
  * @author robo
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="KdybyTests\Doctrine\CmsEmployeeRepository")
  * @ORM\Table(name="cms_employees")
  */
 class CmsEmployee
@@ -247,7 +247,7 @@ class CmsEmployee
  * Description of CmsGroup
  *
  * @author robo
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="KdybyTests\Doctrine\CmsGroupRepository")
  * @ORM\Table(name="cms_groups")
  */
 class CmsGroup
@@ -284,7 +284,7 @@ class CmsGroup
 
 
 /**
- * @ORM\Entity
+ * @ORM\Entity()
  * @ORM\Table(name="cms_phonenumbers")
  */
 class CmsPhoneNumber
@@ -305,7 +305,7 @@ class CmsPhoneNumber
 
 
 /**
- * @ORM\Entity
+ * @ORM\Entity()
  * @ORM\Table(name="cms_users")
  */
 class CmsUser
@@ -461,7 +461,7 @@ class CmsUser
 
 
 /**
- * @ORM\Entity
+ * @ORM\Entity()
  * @ORM\Table(name="cms_orders")
  */
 class CmsOrder

--- a/tests/KdybyTests/Doctrine/models/cms.repositories.php
+++ b/tests/KdybyTests/Doctrine/models/cms.repositories.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace KdybyTests\Doctrine;
+
+use Kdyby\Doctrine\EntityRepository;
+
+
+
+class CmsAddressRepository extends EntityRepository
+{
+
+}
+
+
+class CmsArticleRepository extends EntityRepository
+{
+
+}
+
+
+class CmsCommentRepository extends EntityRepository
+{
+
+}
+
+
+class CmsEmployeeRepository extends EntityRepository
+{
+
+}
+
+
+class CmsGroupRepository extends EntityRepository
+{
+
+}


### PR DESCRIPTION
[Fixes #179]

## "The old way" registration

This got broken with custom RepositoryFactory, that was implemented only half way, I'm sorry about this. The following syntax should be fixed and working fine with this PR.

```yml

services:
	-
		class: KdybyTests\Doctrine\CmsEmployeeRepository
		factory: @Kdyby\Doctrine\EntityManager::getRepository(KdybyTests\Doctrine\CmsEmployee)

	-
		class: KdybyTests\Doctrine\CmsGroupRepository
		factory: @Kdyby\Doctrine\EntityManager::getDao(KdybyTests\Doctrine\CmsGroup)
```

please note that the `getDao` method is deprecated


## Custom repositories without services

Often, you might wanna custom repository, without registering it as a service. You can still do that

```php
/**
 * @ORM\Entity(repositoryClass="KdybyTests\Doctrine\CmsCommentRepository")
 * @ORM\Table(name="cms_comments")
 */
class CmsComment
```

This will work, but as expected, you won't be able to inject the repository using DI Container, because it won't be registered


## Custom repositories as services

You bind the repository, as you would normally

```php
/**
 * @ORM\Entity(repositoryClass="KdybyTests\Doctrine\CmsAddressRepository")
 * @ORM\Table(name="cms_addresses")
 */
class CmsAddress
```

but you also register it as a service

```yml
services:
	- KdybyTests\Doctrine\CmsAddressRepository
```

This grants you the ability to actually configure the repository using the DI Container, without using the ugly `onDaoCreate` event.
Unfortunatelly, this combination requires the OrmExtension to actually know what repository is bound to what entity. That can't be done reliably without the knowledge of metadata, that is available only after the container is compiled. That's why there is now a hack, that instantiates the DI Container (relatively safely) during the compilation and fetches the metadata from it. This has a side-effect of basic metadata validation in compile-time.

The DI Container is instantiated in compile-time only when the extension has no other option. By tagging the services, you can completely bypass this behaviour.

```yml
services:
	- 
		class: KdybyTests\Doctrine\CmsAddressRepository
		tags: 
			- doctrine.repositoryEntity: KdybyTests\Doctrine\CmsAddress
```

this provides the neccesary metadata (that you sadly have to maintain manually, there are no validation in place, yet) and the need for creating the DIC instance in compile-time is no longer.


## Questions for you

1. Have I explained this properly? 
2. Did I break any of your use-cases? 
3. DId I forget any of your use-cases?
4. Do you have an idea how to get the metadata in a better way [than instantiating the container](https://github.com/Kdyby/Doctrine/pull/191/files#diff-ccc8ba07edfa3a425ddfe564acb50656R824)? 

Odpovědi česky nevadí, lepší než vůbec nic :) 