### PR TITLE
Warning about the usage of safePersist and NonLockingUniqueInserter

### DIFF
--- a/src/Kdyby/Doctrine/EntityManager.php
+++ b/src/Kdyby/Doctrine/EntityManager.php
@@ -179,6 +179,12 @@ class EntityManager extends Doctrine\ORM\EntityManager
 
 
 	/**
+	 * Tries to persist the given entity and returns FALSE if an unique
+	 * constaint was violated.
+	 *
+	 * Warning: On success you must NOT use the passed entity further
+	 * in your application. Use the returned one instead!
+	 *
 	 * @param $entity
 	 * @throws \Doctrine\DBAL\DBALException
 	 * @throws \Exception

--- a/src/Kdyby/Doctrine/Tools/NonLockingUniqueInserter.php
+++ b/src/Kdyby/Doctrine/Tools/NonLockingUniqueInserter.php
@@ -77,6 +77,9 @@ class NonLockingUniqueInserter extends Nette\Object
 	 * When entity have columns for required associations, this will fail.
 	 * Calls $em->flush().
 	 *
+	 * Warning: You must NOT use the passed entity further in your application.
+	 * Use the returned one instead!
+	 *
 	 * @todo fix error codes! PDO is returning database-specific codes
 	 *
 	 * @param object $entity


### PR DESCRIPTION
The documentation states that ```NonLockingUniqueInserter::persist()``` calls ```$em->flush()``` internally but it should also clearly say that it returns **ANOTHER** instance of the entity class on success (which is obvious because it returns the result of ```$em->merge()``` but you don't know that until you examine the source code).