### PR TITLE
Doctrine Migrations integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,13 @@
 		"latte/latte": "~2.3@dev",
 		"tracy/tracy": "~2.3@dev",
 
+		"doctrine/migrations": "~1.0@dev",
+
 		"dg/dibi" : "~2.0",
 		"nette/tester": "~1.3@rc"
+	},
+	"suggest": {
+		"doctrine/migrations": "If you want to use migrations via MigrationsExtension"
 	},
 	"autoload": {
 		"psr-0": {

--- a/src/Kdyby/Doctrine/Console/DiffCommand.php
+++ b/src/Kdyby/Doctrine/Console/DiffCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Pavel Kouřil <pk@pavelkouril.cz>
  */
-class DiffCommand extends \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand
+class DiffCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand
 {
 
     /**

--- a/src/Kdyby/Doctrine/Console/DiffCommand.php
+++ b/src/Kdyby/Doctrine/Console/DiffCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class DiffCommand extends \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand
+{
+
+    /**
+     * @var \Kdyby\Doctrine\Tools\CacheCleaner
+     * @inject
+     */
+    public $cacheCleaner;
+
+
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $this->cacheCleaner->invalidate();
+    }
+
+}

--- a/src/Kdyby/Doctrine/Console/ExecuteCommand.php
+++ b/src/Kdyby/Doctrine/Console/ExecuteCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class ExecuteCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand
+{
+
+	/**
+	 * @var \Kdyby\Doctrine\Tools\CacheCleaner
+	 * @inject
+	 */
+	public $cacheCleaner;
+
+
+
+	protected function initialize(InputInterface $input, OutputInterface $output)
+	{
+		parent::initialize($input, $output);
+		$this->cacheCleaner->invalidate();
+	}
+
+}

--- a/src/Kdyby/Doctrine/Console/GenerateCommand.php
+++ b/src/Kdyby/Doctrine/Console/GenerateCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class GenerateCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand
+{
+
+	/**
+	 * @var \Kdyby\Doctrine\Tools\CacheCleaner
+	 * @inject
+	 */
+	public $cacheCleaner;
+
+
+
+	protected function initialize(InputInterface $input, OutputInterface $output)
+	{
+		parent::initialize($input, $output);
+		$this->cacheCleaner->invalidate();
+	}
+
+}

--- a/src/Kdyby/Doctrine/Console/LatestCommand.php
+++ b/src/Kdyby/Doctrine/Console/LatestCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class LatestCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\LatestCommand
+{
+
+	/**
+	 * @var \Kdyby\Doctrine\Tools\CacheCleaner
+	 * @inject
+	 */
+	public $cacheCleaner;
+
+
+
+	protected function initialize(InputInterface $input, OutputInterface $output)
+	{
+		parent::initialize($input, $output);
+		$this->cacheCleaner->invalidate();
+	}
+
+}

--- a/src/Kdyby/Doctrine/Console/MigrateCommand.php
+++ b/src/Kdyby/Doctrine/Console/MigrateCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class MigrateCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand
+{
+
+	/**
+	 * @var \Kdyby\Doctrine\Tools\CacheCleaner
+	 * @inject
+	 */
+	public $cacheCleaner;
+
+
+
+	protected function initialize(InputInterface $input, OutputInterface $output)
+	{
+		parent::initialize($input, $output);
+		$this->cacheCleaner->invalidate();
+	}
+
+}

--- a/src/Kdyby/Doctrine/Console/StatusCommand.php
+++ b/src/Kdyby/Doctrine/Console/StatusCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class StatusCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand
+{
+
+	/**
+	 * @var \Kdyby\Doctrine\Tools\CacheCleaner
+	 * @inject
+	 */
+	public $cacheCleaner;
+
+
+
+	protected function initialize(InputInterface $input, OutputInterface $output)
+	{
+		parent::initialize($input, $output);
+		$this->cacheCleaner->invalidate();
+	}
+
+}

--- a/src/Kdyby/Doctrine/Console/VersionCommand.php
+++ b/src/Kdyby/Doctrine/Console/VersionCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class VersionCommand extends Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand
+{
+
+	/**
+	 * @var \Kdyby\Doctrine\Tools\CacheCleaner
+	 * @inject
+	 */
+	public $cacheCleaner;
+
+
+
+	protected function initialize(InputInterface $input, OutputInterface $output)
+	{
+		parent::initialize($input, $output);
+		$this->cacheCleaner->invalidate();
+	}
+
+}

--- a/src/Kdyby/Doctrine/DI/MigrationsExtension.php
+++ b/src/Kdyby/Doctrine/DI/MigrationsExtension.php
@@ -30,7 +30,6 @@ class MigrationsExtension extends Nette\DI\CompilerExtension
 		foreach ($services as $i => $command) {
 			$builder->addDefinition($this->prefix('cli.migrations.' . $i))
 				->addTag(Kdyby\Console\DI\ConsoleExtension::TAG_COMMAND)
-				->setInject(FALSE)
 				->setClass($command);
 		}
 	}

--- a/src/Kdyby/Doctrine/DI/MigrationsExtension.php
+++ b/src/Kdyby/Doctrine/DI/MigrationsExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\DI;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class MigrationsExtension extends Nette\DI\CompilerExtension
+{
+	
+	public function loadConfiguration()
+	{
+		$builder = $this->getContainerBuilder();
+		$services = $this->loadFromFile(__DIR__ . '/migrations.neon');
+
+		foreach ($services as $i => $command) {
+			$builder->addDefinition($this->prefix('cli.migrations.' . $i))
+				->addTag(Kdyby\Console\DI\ConsoleExtension::TAG_COMMAND)
+				->setInject(FALSE)
+				->setClass($command);
+		}
+	}
+	
+}

--- a/src/Kdyby/Doctrine/DI/migrations.neon
+++ b/src/Kdyby/Doctrine/DI/migrations.neon
@@ -1,0 +1,7 @@
+- Kdyby\Doctrine\Console\ExecuteCommand
+- Kdyby\Doctrine\Console\DiffCommand
+- Kdyby\Doctrine\Console\GenerateCommand
+- Kdyby\Doctrine\Console\MigrateCommand
+- Kdyby\Doctrine\Console\StatusCommand
+- Kdyby\Doctrine\Console\VersionCommand
+- Kdyby\Doctrine\Console\LatestCommand

--- a/tests/KdybyTests/Doctrine/DI/MigrationsExtension.phpt
+++ b/tests/KdybyTests/Doctrine/DI/MigrationsExtension.phpt
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\DI\MigrationsExtension.
+ *
+ * @testCase Kdyby\Doctrine\DI\MigrationsExtension
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ * @package Kdyby\Doctrine\DI
+ */
+
+namespace KdybyTests\Doctrine\DI;
+
+use Kdyby;
+use Nette;
+use Tester;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Pavel Kouřil <pk@pavelkouril.cz>
+ */
+class MigrationsExtensionTest extends Tester\TestCase
+{
+
+	/**
+	 * @param string $file
+	 * @param array $parameters
+	 *
+	 * @return \Nette\DI\Container
+	 */
+	private function createContainer($file, array $parameters = [])
+	{
+		$loader = new Nette\DI\ContainerLoader(TEMP_DIR, true);
+		$class = $loader->load('', function(Nette\DI\Compiler $compiler) use ($file, $parameters) {
+			$compiler->addExtension('extensions', new Nette\DI\Extensions\ExtensionsExtension());
+			if ($parameters) {
+				$compiler->addConfig(['parameters' => $parameters]);
+			}
+			$compiler->loadConfig($file);
+		});
+		return new $class;
+	}
+
+
+
+	public function testRegisterCommands()
+	{
+		$container = $this->createContainer(__DIR__ . '/config/migrations.extension.neon');
+		Assert::count(7, $container->findByTag(Kdyby\Console\DI\ConsoleExtension::TAG_COMMAND));
+	}
+
+}
+
+\run(new MigrationsExtensionTest());

--- a/tests/KdybyTests/Doctrine/DI/config/migrations.extension.neon
+++ b/tests/KdybyTests/Doctrine/DI/config/migrations.extension.neon
@@ -1,0 +1,2 @@
+extensions:
+    migrations: Kdyby\Doctrine\DI\MigrationsExtension


### PR DESCRIPTION
Hi,

this PR adds optional integration of Doctrine Migrations via new `MigrationsExtension`.

This `MigrationsExtension` registers all 7 commands from doctrine/migrations package (`diff`, `execute`, `generate`, `latest`, `migrate`, `status`, `version`) and ensures that every command will also clear doctrine cache before executing said command - which is especially useful when working with migrations.

Is this even wanted in Kdyby/Doctrine or should this be solved in a totally separate package?

If this would be a wanted addition to this library, there are some things to discuss. Like:
- maybe stuff in `Kdyby\Doctrine\Console` NS could be separated into multiple NS? It feels kinda cluttered right now with so many commands inside
- what tests should be written for the extension? right now there's only one, to check if the extension correctly registers all 7 commands
- should I also write some "small" documentation in docs/en?
- should we also support specifiyng setting up the migrations in config.neon via extension configuration? right now only the standard way of having `migrations.yml` or `migrations.xml` file is supported