### PR TITLE
Allow custom annotation driver class

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -617,7 +617,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			);
 		}
 
-		$serviceName = $this->prefix($prefix . '.driver.' . str_replace('\\', '_', $namespace) . '.' . $impl . 'Impl');
+		$serviceName = $this->prefix($prefix . '.driver.' . str_replace('\\', '_', $namespace) . '.' . str_replace('\\', '_', $impl) . 'Impl');
 
 		$this->getContainerBuilder()->addDefinition($serviceName)
 			->setClass('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver')


### PR DESCRIPTION
I was trying to convince  Kdyby/Doctrine to use the default annotation driver from doctrine instead of the kdyby implementation. I tried this configuration:

```
kdyby.doctrine:
	metadata:
		App: Doctrine\ORM\Mapping\Driver\AnnotationDriver(
			reader: @Doctrine\Common\Annotations\Reader
			paths: '%appDir%/src/Module/AdminModule'
		)
```

Turns out it is currently impossible to use an implementation which is not in `OrmExtension::$metadataDriverClasses`. This PR makes that possible.

Of course in case I've the syntax wrong and it is supposed to be done differently, please tell me.