### PR TITLE
composer: add Tracy as required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"nette/neon": "~2.3@dev",
 		"nette/utils": "~2.3@dev",
 		"nette/robot-loader": "~2.3@dev",
+		"tracy/tracy": "~2.3@dev",
 
 		"doctrine/orm": "~2.5",
 		"doctrine/dbal": "~2.5",
@@ -51,7 +52,6 @@
 		"nette/tokenizer": "~2.2@dev",
 		"nette/utils": "~2.3@dev",
 		"latte/latte": "~2.3@dev",
-		"tracy/tracy": "~2.3@dev",
 
 		"dg/dibi" : "~2.0",
 		"nette/tester": "~1.3@rc"


### PR DESCRIPTION
I often get these messages, while using this package.

> PHP Fatal error:  Interface 'Tracy\IBarPanel' not found in /.../vendor/kdyby/doctrine/src/Kdyby/Doctrine/Diagnostics/Panel.php on line 39

[Panel has lots of dependencies on Tracy](https://github.com/Kdyby/Doctrine/blob/c707096d4a674cad54b459266181a4ed412b7003/src/Kdyby/Doctrine/Diagnostics/Panel.php#L23-L28), this should fix it.