### PR TITLE
CacheCleaner: release Kdyby lock for EntityManager

### DIFF
--- a/src/Kdyby/Doctrine/Tools/CacheCleaner.php
+++ b/src/Kdyby/Doctrine/Tools/CacheCleaner.php
@@ -10,6 +10,7 @@
 
 namespace Kdyby\Doctrine\Tools;
 
+use Doctrine;
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\ClearableCache;
 use Kdyby;
@@ -24,7 +25,7 @@ class CacheCleaner extends Nette\Object
 {
 
 	/**
-	 * @var \Kdyby\Doctrine\EntityManager
+	 * @var \Doctrine\ORM\EntityManager
 	 */
 	private $entityManager;
 
@@ -35,7 +36,7 @@ class CacheCleaner extends Nette\Object
 
 
 
-	public function __construct(Kdyby\Doctrine\EntityManager $entityManager)
+	public function __construct(Doctrine\ORM\EntityManager $entityManager)
 	{
 		$this->entityManager = $entityManager;
 	}


### PR DESCRIPTION
This allows to use other then Kdyby version of EntityManager

Functionality remains the same.