### PR TITLE
Remove @property-read from attribute traits

### DIFF
--- a/src/Kdyby/Doctrine/Entities/Attributes/Identifier.php
+++ b/src/Kdyby/Doctrine/Entities/Attributes/Identifier.php
@@ -16,8 +16,6 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @author Martin Štekl <martin.stekl@gmail.com>
- *
- * @property-read int $id
  */
 trait Identifier
 {

--- a/src/Kdyby/Doctrine/Entities/Attributes/UniversallyUniqueIdentifier.php
+++ b/src/Kdyby/Doctrine/Entities/Attributes/UniversallyUniqueIdentifier.php
@@ -17,8 +17,6 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @author Martin Štekl <martin.stekl@gmail.com>
  * @author Filip Klimeš <filip@filipklimes.cz>
- *
- * @property-read string $id
  */
 trait UniversallyUniqueIdentifier
 {


### PR DESCRIPTION
Some people (me including) may use these traits without MagicAccessors trait and then IDE suggests id property, which will produce error.

These annotations can be be easily written to entity class (since you are writing them anyway, when using magic accessors, if you want your IDE to suggest parameters)