### PR TITLE
ResolveTargetEntityListener - not loadClassMetadata on each request fix #230

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
+tests/mysql.local.neon
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,23 @@ php:
 
 env:
   matrix:
-    - NETTE=nette-2.3-dev
+    - NETTE=nette-2.4-dev
+    - NETTE=nette-2.4
     - NETTE=nette-2.3
 
 matrix:
   include:
     - php: 5.6
       env: NETTE=nette-2.3 COMPOSER_EXTRA_ARGS="--prefer-lowest --prefer-stable"
+  exclude:
+    - php: 5.4
+      env: NETTE=nette-2.4-dev
+    - php: 5.4
+      env: NETTE=nette-2.4
+    - php: 5.5
+      env: NETTE=nette-2.4-dev
+    - php: 5.5
+      env: NETTE=nette-2.4
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: false
 
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 env:
   - NETTE=nette-2.3-dev
   - NETTE=nette-2.3
@@ -18,22 +22,21 @@ matrix:
     - php: hhvm
 
 before_install:
-  - composer self-update
-
-install:
+  - travis_retry composer self-update
   - mkdir -p vendor/bin
   - wget -O vendor/bin/composer-nette https://raw.githubusercontent.com/Kdyby/TesterExtras/master/bin/composer-nette.php
   - php vendor/bin/composer-nette
-  - composer install --no-interaction --prefer-source
 
-before_script:
-  - composer create-project --prefer-source --no-interaction jakub-onderka/php-parallel-lint vendor/php-parallel-lint ~0.8
-  - php vendor/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
-  - composer create-project --prefer-source --no-interaction nette/code-checker vendor/code-checker ~2.2
-  - php vendor/code-checker/src/code-checker.php --short-arrays -d src
-  - php vendor/code-checker/src/code-checker.php --short-arrays -d tests
+install:
+  - travis_retry composer update --no-interaction --prefer-dist
+  - travis_retry composer create-project --no-interaction jakub-onderka/php-parallel-lint /tmp/php-parallel-lint
+  - travis_retry composer create-project --no-interaction nette/code-checker /tmp/code-checker ~2.5
 
-script: vendor/bin/tester -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
+script:
+  - vendor/bin/tester -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
+  - php /tmp/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
+  - php /tmp/code-checker/src/code-checker.php --short-arrays -d src
+  - php /tmp/code-checker/src/code-checker.php --short-arrays -d tests
 
 after_failure:
   - 'for i in $(find ./tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ cache:
     directories:
         - $HOME/.composer/cache
 
-env:
-  - NETTE=nette-2.3-dev
-  - NETTE=nette-2.3
-
 php:
   - 5.4
   - 5.5
@@ -17,26 +13,32 @@ php:
   - 7.0
   - hhvm
 
+env:
+  matrix:
+    - NETTE=nette-2.3-dev
+    - NETTE=nette-2.3
+
 matrix:
+  include:
+    - php: 5.6
+      env: NETTE=nette-2.3 COMPOSER_EXTRA_ARGS="--prefer-lowest --prefer-stable"
   allow_failures:
     - php: hhvm
 
 before_install:
   - travis_retry composer self-update
-  - mkdir -p vendor/bin
-  - wget -O vendor/bin/composer-nette https://raw.githubusercontent.com/Kdyby/TesterExtras/master/bin/composer-nette.php
-  - php vendor/bin/composer-nette
+  - wget -O /tmp/composer-nette https://raw.githubusercontent.com/Kdyby/TesterExtras/master/bin/composer-nette.php
+  - php /tmp/composer-nette
 
 install:
-  - travis_retry composer update --no-interaction --prefer-dist
+  - travis_retry composer update --no-interaction --prefer-dist $COMPOSER_EXTRA_ARGS
   - travis_retry composer create-project --no-interaction jakub-onderka/php-parallel-lint /tmp/php-parallel-lint
   - travis_retry composer create-project --no-interaction kdyby/code-checker /tmp/code-checker
 
 script:
-  - vendor/bin/tester -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
+  - vendor/bin/tester -s -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
   - php /tmp/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
-  - php /tmp/code-checker/src/code-checker.php --short-arrays -d src
-  - php /tmp/code-checker/src/code-checker.php --short-arrays -d tests
+  - php /tmp/code-checker/src/code-checker.php --short-arrays
 
 after_failure:
   - 'for i in $(find ./tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 install:
   - travis_retry composer update --no-interaction --prefer-dist
   - travis_retry composer create-project --no-interaction jakub-onderka/php-parallel-lint /tmp/php-parallel-lint
-  - travis_retry composer create-project --no-interaction nette/code-checker /tmp/code-checker ~2.5
+  - travis_retry composer create-project --no-interaction kdyby/code-checker /tmp/code-checker
 
 script:
   - vendor/bin/tester -p php -c ./tests/php.ini-unix ./tests/KdybyTests/

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.1-dev"
+			"dev-nette-2.3": "3.1-dev"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
 		"tracy/tracy": "~2.3@dev",
 
 		"dg/dibi" : "~2.0",
-		"nette/tester": "~1.3@rc"
+		"nette/tester": "~1.7"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.0-dev"
+			"dev-master": "3.1-dev"
 		}
 	}
 }

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -88,7 +88,7 @@ class Article
 
 	use \Kdyby\Doctrine\Entities\MagicAccessors;
 	use \Kdyby\Doctrine\Entities\Attributes\Identifier; // Using Identifier trait for id column
-	
+
 	// ...
 }
 ```

--- a/docs/en/optimizing-query-objects.md
+++ b/docs/en/optimizing-query-objects.md
@@ -42,7 +42,7 @@ class ArticlesQuery extends QueryObject
 
     return $qb;
   }
-  
+
   // ...
 ```
 
@@ -85,4 +85,3 @@ It will only initialize the joined collection for each one of those articles.
 
 What this gives us? We now have the same result set as from the first query, but this time we've sent two SQL queries to the database,
 of which both transmitted **a lot** less data and the hydrator was able to process it much faster, making our application faster.
-

--- a/src/Kdyby/Doctrine/Console/ColoredSqlOutput.php
+++ b/src/Kdyby/Doctrine/Console/ColoredSqlOutput.php
@@ -124,6 +124,46 @@ class ColoredSqlOutput extends Nette\Object implements OutputInterface
 	/**
 	 * {@inheritdoc}
 	 */
+	public function isQuiet()
+	{
+		return $this->output->isQuiet();
+	}
+
+
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isVerbose()
+	{
+		return $this->output->isVerbose();
+	}
+
+
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isVeryVerbose()
+	{
+		return $this->output->isVeryVerbose();
+	}
+
+
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isDebug()
+	{
+		return $this->output->isDebug();
+	}
+
+
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function setFormatter(OutputFormatterInterface $formatter)
 	{
 		return $this->output->setFormatter($formatter);

--- a/src/Kdyby/Doctrine/Console/CommandHelper.php
+++ b/src/Kdyby/Doctrine/Console/CommandHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\Console;
+
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Kdyby\Console\ContainerHelper;
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+final class CommandHelper
+{
+
+	/**
+	 * Private constructor. This class is not meant to be instantiated.
+	 */
+	private function __construct()
+	{
+	}
+
+
+
+	public static function setApplicationEntityManager(ContainerHelper $containerHelper, $emName)
+	{
+		/** @var \Kdyby\Doctrine\EntityManager $em */
+		$em = $containerHelper->getByType('Kdyby\Doctrine\Registry')->getManager($emName);
+		/** @var \Symfony\Component\Console\Helper\HelperSet $helperSet */
+		$helperSet = $containerHelper->getHelperSet();
+		$helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
+		$helperSet->set(new EntityManagerHelper($em), 'em');
+	}
+
+}

--- a/src/Kdyby/Doctrine/Console/ConvertMappingCommand.php
+++ b/src/Kdyby/Doctrine/Console/ConvertMappingCommand.php
@@ -11,12 +11,9 @@
 namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -41,9 +38,25 @@ class ConvertMappingCommand extends Doctrine\ORM\Tools\Console\Command\ConvertMa
 
 
 
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/GenerateEntitiesCommand.php
+++ b/src/Kdyby/Doctrine/Console/GenerateEntitiesCommand.php
@@ -11,12 +11,9 @@
 namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -41,9 +38,28 @@ class GenerateEntitiesCommand extends Doctrine\ORM\Tools\Console\Command\Generat
 
 
 
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/GenerateProxiesCommand.php
+++ b/src/Kdyby/Doctrine/Console/GenerateProxiesCommand.php
@@ -11,12 +11,9 @@
 namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -41,9 +38,28 @@ class GenerateProxiesCommand extends Doctrine\ORM\Tools\Console\Command\Generate
 
 
 
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/InfoCommand.php
+++ b/src/Kdyby/Doctrine/Console/InfoCommand.php
@@ -11,12 +11,9 @@
 namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -41,9 +38,28 @@ class InfoCommand extends Doctrine\ORM\Tools\Console\Command\InfoCommand
 
 
 
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/SchemaCreateCommand.php
+++ b/src/Kdyby/Doctrine/Console/SchemaCreateCommand.php
@@ -12,12 +12,9 @@ namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
 use Doctrine\ORM\Tools\SchemaTool;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -43,11 +40,27 @@ class SchemaCreateCommand extends Doctrine\ORM\Tools\Console\Command\SchemaTool\
 
 
 	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
 	 * {@inheritdoc}
 	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/SchemaDropCommand.php
+++ b/src/Kdyby/Doctrine/Console/SchemaDropCommand.php
@@ -12,12 +12,9 @@ namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
 use Doctrine\ORM\Tools\SchemaTool;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -43,11 +40,27 @@ class SchemaDropCommand extends Doctrine\ORM\Tools\Console\Command\SchemaTool\Dr
 
 
 	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
 	 * {@inheritdoc}
 	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/SchemaUpdateCommand.php
+++ b/src/Kdyby/Doctrine/Console/SchemaUpdateCommand.php
@@ -12,12 +12,9 @@ namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
 use Doctrine\ORM\Tools\SchemaTool;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -43,11 +40,27 @@ class SchemaUpdateCommand extends Doctrine\ORM\Tools\Console\Command\SchemaTool\
 
 
 	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
 	 * {@inheritdoc}
 	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/Console/ValidateSchemaCommand.php
+++ b/src/Kdyby/Doctrine/Console/ValidateSchemaCommand.php
@@ -11,12 +11,9 @@
 namespace Kdyby\Doctrine\Console;
 
 use Doctrine;
-use Kdyby;
-use Nette;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Tracy\Debugger;
 
 
 
@@ -41,9 +38,28 @@ class ValidateSchemaCommand extends Doctrine\ORM\Tools\Console\Command\ValidateS
 
 
 
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure()
+	{
+		parent::configure();
+		$this->addOption('em', NULL, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command');
+	}
+
+
+
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
 		parent::initialize($input, $output);
+
+		if ($input->getOption('em')) {
+			CommandHelper::setApplicationEntityManager($this->getHelper('container'), $input->getOption('em'));
+		}
+
 		$this->cacheCleaner->invalidate();
 	}
 

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -312,7 +312,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		Validators::assertField($config['dql'], 'hints', 'array');
 
 		$autoGenerateProxyClasses = is_bool($config['autoGenerateProxyClasses'])
-			? ($config['autoGenerateProxyClasses'] ? AbstractProxyFactory::AUTOGENERATE_ALWAYS : AbstractProxyFactory::AUTOGENERATE_NEVER)
+			? ($config['autoGenerateProxyClasses'] ? AbstractProxyFactory::AUTOGENERATE_ALWAYS : AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS)
 			: $config['autoGenerateProxyClasses'];
 
 		$configuration = $builder->addDefinition($this->prefix($name . '.ormConfiguration'))

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -613,7 +613,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 		/** @var string $impl */
 		if (isset($this->metadataDriverClasses[$impl])) {
-			$driver->setEntity($this->metadataDriverClasses[$impl]);
+			$driver = new Statement($this->metadataDriverClasses[$impl], $driver->arguments);
 		}
 
 		if (is_string($driver->getEntity()) && substr($driver->getEntity(), 0, 1) === '@') {

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -607,17 +607,18 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			$driver = new Statement(self::ANNOTATION_DRIVER, is_array($paths) ? $paths : [$paths]);
 		}
 
-		$impl = $driver instanceof \stdClass ? $driver->value : ($driver instanceof Statement ? $driver->entity : (string) $driver);
+		$impl = $driver instanceof \stdClass ? $driver->value : ($driver instanceof Statement ? $driver->getEntity() : (string) $driver);
 		list($driver) = CacheHelpers::filterArgs($driver);
 		/** @var Statement $driver */
 
+		/** @var string $impl */
 		if (isset($this->metadataDriverClasses[$impl])) {
-			$driver->entity = $this->metadataDriverClasses[$impl];
+			$driver->setEntity($this->metadataDriverClasses[$impl]);
 		}
 
-		if (is_string($driver->entity) && substr($driver->entity, 0, 1) === '@') {
-			$metadataDriver->addSetup('addDriver', [$driver->entity, $namespace]);
-			return $driver->entity;
+		if (is_string($driver->getEntity()) && substr($driver->getEntity(), 0, 1) === '@') {
+			$metadataDriver->addSetup('addDriver', [$driver->getEntity(), $namespace]);
+			return $driver->getEntity();
 		}
 
 		if ($impl === self::ANNOTATION_DRIVER) {
@@ -631,7 +632,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 		$this->getContainerBuilder()->addDefinition($serviceName)
 			->setClass('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver')
-			->setFactory($driver->entity, $driver->arguments)
+			->setFactory($driver->getEntity(), $driver->arguments)
 			->setAutowired(FALSE)
 			->setInject(FALSE);
 
@@ -678,7 +679,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 		$disabled = TRUE;
 		foreach ($this->configuredManagers as $managerName => $_) {
-			$factoryClassName = $builder->getDefinition($this->prefix($managerName . '.repositoryFactory'))->class;
+			$factoryClassName = $builder->getDefinition($this->prefix($managerName . '.repositoryFactory'))->getClass();
 			if ($factoryClassName === 'Kdyby\Doctrine\RepositoryFactory' || in_array('Kdyby\Doctrine\RepositoryFactory', class_parents($factoryClassName), TRUE)) {
 				$disabled = FALSE;
 			}
@@ -728,21 +729,21 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 			if ($boundEntity = $originalDef->getTag(self::TAG_REPOSITORY_ENTITY)) {
 				if (!is_string($boundEntity) || !class_exists($boundEntity)) {
-					throw new Nette\Utils\AssertionException(sprintf('The entity "%s" for repository "%s" cannot be autoloaded.', $boundEntity, $originalDef->class));
+					throw new Nette\Utils\AssertionException(sprintf('The entity "%s" for repository "%s" cannot be autoloaded.', $boundEntity, $originalDef->getClass()));
 				}
 				$entityArgument = $boundEntity;
 
 			} else {
 				$entityArgument = new Code\PhpLiteral('"%entityName%"');
-				$this->postCompileRepositoriesQueue[$boundManagers[0]][] = [ltrim($originalDef->class, '\\'), $originalServiceName];
+				$this->postCompileRepositoriesQueue[$boundManagers[0]][] = [ltrim($originalDef->getClass(), '\\'), $originalServiceName];
 			}
 
 			$builder->removeDefinition($originalServiceName);
 			$builder->addDefinition($originalServiceName)
-				->setClass($originalDef->class)
+				->setClass($originalDef->getClass())
 				->setFactory(sprintf('@%s::getRepository', $this->configuredManagers[$boundManagers[0]]), [$entityArgument]);
 
-			$serviceMap[$boundManagers[0]][$originalDef->class] = $factoryServiceName;
+			$serviceMap[$boundManagers[0]][$originalDef->getClass()] = $factoryServiceName;
 		}
 
 		foreach ($this->configuredManagers as $managerName => $_) {
@@ -772,7 +773,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 	public function afterCompile(Code\ClassType $class)
 	{
-		$init = $class->methods['initialize'];
+		$init = $class->getMethod('initialize');
 
 		if ($this->isTracyPresent()) {
 			$init->addBody('Kdyby\Doctrine\Diagnostics\Panel::registerBluescreen($this);');

--- a/src/Kdyby/Doctrine/Diagnostics/Panel.php
+++ b/src/Kdyby/Doctrine/Diagnostics/Panel.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Types\Type;
 use Kdyby;
 use Nette;
 use Nette\Utils\Strings;
-use Nette\Utils\Callback;
 use Tracy\Bar;
 use Tracy\BlueScreen;
 use Tracy\Debugger;
@@ -906,7 +905,7 @@ class Panel extends Nette\Object implements IBarPanel, Doctrine\DBAL\Logging\SQL
 
 		// Tracy
 		$this->registerBarPanel(Debugger::getBar());
-		Debugger::getBlueScreen()->addPanel(Callback::closure($this, 'renderQueryException'));
+		Debugger::getBlueScreen()->addPanel([$this, 'renderQueryException']);
 
 		return $this;
 	}
@@ -932,7 +931,7 @@ class Panel extends Nette\Object implements IBarPanel, Doctrine\DBAL\Logging\SQL
 			$this->bindConnection($em->getConnection());
 		}
 
-		Debugger::getBlueScreen()->addPanel(Callback::closure($this, 'renderEntityManagerException'));
+		Debugger::getBlueScreen()->addPanel([$this, 'renderEntityManagerException']);
 
 		return $this;
 	}

--- a/src/Kdyby/Doctrine/Entities/MagicAccessors.php
+++ b/src/Kdyby/Doctrine/Entities/MagicAccessors.php
@@ -141,6 +141,15 @@ trait MagicAccessors
 
 						return $this;
 
+					} elseif (substr($prop, -1) === 's' && isset($properties[$prop = substr($prop, 0, -1) . 'ses'])) {
+						if (!$this->$prop instanceof Collection) {
+							throw UnexpectedValueException::notACollection($this, $prop);
+						}
+
+						$this->$prop->add($args[0]);
+
+						return $this;
+
 					} elseif (isset($properties[$prop])) {
 						throw UnexpectedValueException::notACollection($this, $prop);
 					}
@@ -154,6 +163,13 @@ trait MagicAccessors
 						return $this->{$prop . 's'}->contains($args[0]);
 
 					} elseif (substr($prop, -1) === 'y' && isset($properties[$prop = substr($prop, 0, -1) . 'ies'])) {
+						if (!$this->$prop instanceof Collection) {
+							throw UnexpectedValueException::notACollection($this, $prop);
+						}
+
+						return $this->$prop->contains($args[0]);
+
+					} elseif (substr($prop, -1) === 's' && isset($properties[$prop = substr($prop, 0, -1) . 'ses'])) {
 						if (!$this->$prop instanceof Collection) {
 							throw UnexpectedValueException::notACollection($this, $prop);
 						}
@@ -177,6 +193,15 @@ trait MagicAccessors
 						return $this;
 
 					} elseif (substr($prop, -1) === 'y' && isset($properties[$prop = substr($prop, 0, -1) . 'ies'])) {
+						if (!$this->$prop instanceof Collection) {
+							throw UnexpectedValueException::notACollection($this, $prop);
+						}
+
+						$this->$prop->removeElement($args[0]);
+
+						return $this;
+
+					} elseif (substr($prop, -1) === 's' && isset($properties[$prop = substr($prop, 0, -1) . 'ses'])) {
 						if (!$this->$prop instanceof Collection) {
 							throw UnexpectedValueException::notACollection($this, $prop);
 						}

--- a/src/Kdyby/Doctrine/Events.php
+++ b/src/Kdyby/Doctrine/Events.php
@@ -116,6 +116,14 @@ final class Events
 	const loadClassMetadata = 'Doctrine\\ORM\\Event::loadClassMetadata';
 
 	/**
+	 * The onClassMetadataNotFound event occurs whenever loading metadata for a class
+	 * failed.
+	 *
+	 * @var string
+	 */
+	const onClassMetadataNotFound = 'Doctrine\\ORM\\Event::onClassMetadataNotFound';
+
+	/**
 	 * The preFlush event occurs when the EntityManager#flush() operation is invoked,
 	 * but before any changes to managed entities have been calculated. This event is
 	 * always raised right after EntityManager#flush() call.

--- a/src/Kdyby/Doctrine/Helpers.php
+++ b/src/Kdyby/Doctrine/Helpers.php
@@ -161,7 +161,7 @@ class Helpers extends Nette\Object
 					$query = substr($query, $offset);
 					$offset = 0;
 				} else { // find matching quote or comment end
-					while (preg_match('~' . ($found == '/*' ? '\\*/' : (preg_match('~-- |#~', $found) ? "\n" : "$found|\\\\.")) . '|$~s', $query, $match, PREG_OFFSET_CAPTURE, $offset)) { //! respect sql_mode NO_BACKSLASH_ESCAPES
+					while (preg_match('~' . ($found === '/*' ? '\\*/' : (preg_match('~-- |#~', $found) ? "\n" : "$found|\\\\.")) . '|$~s', $query, $match, PREG_OFFSET_CAPTURE, $offset)) { //! respect sql_mode NO_BACKSLASH_ESCAPES
 						$s = $match[0][0];
 						$offset = $match[0][1] + strlen($s);
 						if ($s[0] !== '\\') {

--- a/src/Kdyby/Doctrine/Mapping/ClassMetadataFactory.php
+++ b/src/Kdyby/Doctrine/Mapping/ClassMetadataFactory.php
@@ -70,12 +70,7 @@ class ClassMetadataFactory extends Doctrine\ORM\Mapping\ClassMetadataFactory
 			throw new Kdyby\Doctrine\MissingClassException("Metadata of class $name was not found, because the class is missing or cannot be autoloaded.");
 		}
 
-		$result = parent::loadMetadata($name);
-		if ($name !== $origName) {
-			$this->setMetadataFor($origName, $this->getMetadataFor($name));
-		}
-
-		return $result;
+		return parent::loadMetadata($origName);
 	}
 
 

--- a/src/Kdyby/Doctrine/Proxy/ProxyAutoloader.php
+++ b/src/Kdyby/Doctrine/Proxy/ProxyAutoloader.php
@@ -18,7 +18,7 @@ use Nette;
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */
-class ProxyAutoloader extends Nette\Object implements Kdyby\Events\Subscriber
+class ProxyAutoloader extends Nette\Object
 {
 
 	/**
@@ -51,20 +51,6 @@ class ProxyAutoloader extends Nette\Object implements Kdyby\Events\Subscriber
 
 
 	/**
-	 * Returns an array of events this subscriber wants to listen to.
-	 *
-	 * @return array
-	 */
-	public function getSubscribedEvents()
-	{
-		return [
-			'Nette\DI\Container::onInitialize' => 'initialize',
-		];
-	}
-
-
-
-	/**
 	 * @param string $proxyDir
 	 * @param string $proxyNamespace
 	 * @return ProxyAutoloader
@@ -72,17 +58,6 @@ class ProxyAutoloader extends Nette\Object implements Kdyby\Events\Subscriber
 	public static function create($proxyDir, $proxyNamespace)
 	{
 		return new static($proxyDir, $proxyNamespace);
-	}
-
-
-
-	/**
-	 * @internal
-	 */
-	public function initialize()
-	{
-		// Needs to be called without arguments.
-		$this->register();
 	}
 
 

--- a/src/Kdyby/Doctrine/Tools/ResolveTargetEntityListener.php
+++ b/src/Kdyby/Doctrine/Tools/ResolveTargetEntityListener.php
@@ -29,7 +29,10 @@ class ResolveTargetEntityListener extends Doctrine\ORM\Tools\ResolveTargetEntity
 	 */
 	public function getSubscribedEvents()
 	{
-		return [Events::loadClassMetadata];
+		return array(
+			Events::loadClassMetadata,
+			Events::onClassMetadataNotFound,
+		);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Connection.phpt
+++ b/tests/KdybyTests/Doctrine/Connection.phpt
@@ -34,7 +34,10 @@ class ConnectionTest extends Tester\TestCase
 	protected function loadMysqlConfig()
 	{
 		$configLoader = new Nette\DI\Config\Loader();
-		$config = $configLoader->load(__DIR__ . '/../../mysql.neon', isset($_ENV['TRAVIS']) ? 'travis' : 'localhost');
+		$config = $configLoader->load(__DIR__ . '/../../mysql.neon');
+		if (is_file(__DIR__ . '/../../mysql.local.neon')) {
+			$config = Nette\DI\Config\Helpers::merge($configLoader->load(__DIR__ . '/../../mysql.local.neon'), $config);
+		}
 
 		return $config['doctrine'];
 	}

--- a/tests/KdybyTests/Doctrine/Console/CommandTestCase.php
+++ b/tests/KdybyTests/Doctrine/Console/CommandTestCase.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Tester;
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+abstract class CommandTestCase extends Tester\TestCase
+{
+
+	/**
+	 * @var array
+	 */
+	protected static $entities = [
+		'KdybyTests\Doctrine\CmsAddress',
+		'KdybyTests\Doctrine\CmsArticle',
+		'KdybyTests\Doctrine\CmsComment',
+		'KdybyTests\Doctrine\CmsEmail',
+		'KdybyTests\Doctrine\CmsEmployee',
+		'KdybyTests\Doctrine\CmsGroup',
+		'KdybyTests\Doctrine\CmsPhoneNumber',
+		'KdybyTests\Doctrine\CmsUser',
+		'KdybyTests\Doctrine\CmsOrder',
+		'KdybyTests\Doctrine\AnnotationDriver\Something\Baz',
+		'KdybyTests\Doctrine\AnnotationDriver\App\FooEntity',
+		'KdybyTests\Doctrine\AnnotationDriver\App\Bar',
+		'KdybyTests\Doctrine\StiUser',
+		'KdybyTests\Doctrine\StiAdmin',
+		'KdybyTests\Doctrine\StiEmployee',
+		'KdybyTests\Doctrine\StiBoss',
+	];
+
+	/**
+	 * @var array
+	 */
+	protected static $tables = [
+		'cms_addresses',
+		'cms_articles',
+		'cms_comments',
+		'cms_emails',
+		'cms_employees',
+		'cms_groups',
+		'cms_phonenumbers',
+		'cms_users',
+		'cms_users_groups',
+		'cms_orders',
+		'baz',
+		'foo_entity',
+		'bar',
+		'sti_users',
+	];
+
+	/**
+	 * @var Nette\DI\Container
+	 */
+	private $serviceLocator;
+
+
+
+	/**
+	 * @param string $command
+	 * @param array  $input
+	 * @param array  $options
+	 *
+	 * @return ApplicationTester
+	 */
+	protected function executeCommand($command, array $input = [], array $options = [])
+	{
+		$applicationTester = new ApplicationTester($this->getApplication());
+		$applicationTester->run(['command' => $command] + $input, $options);
+		return $applicationTester;
+	}
+
+
+
+	/**
+	 * @return Kdyby\Console\Application
+	 */
+	protected function getApplication()
+	{
+		$application = $this->getServiceLocator()->getByType('Kdyby\Console\Application');
+		$application->setAutoExit(FALSE);
+		return $application;
+	}
+
+
+
+	/**
+	 * @return Nette\DI\Container
+	 */
+	protected function getServiceLocator()
+	{
+		if (!$this->serviceLocator) {
+			$this->serviceLocator = $this->createServiceLocator();
+		}
+		return $this->serviceLocator;
+	}
+
+
+
+	/**
+	 * @return Nette\DI\Container
+	 */
+	private function createServiceLocator()
+	{
+		$config = new Nette\Configurator;
+		return $config->setTempDirectory(TEMP_DIR)
+			->addConfig(TEST_DIR . '/nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22')
+			->addConfig(TEST_DIR . '/Doctrine/config/multiple-connections.neon')
+			->addParameters([
+				'appDir' => TEST_DIR,
+				'wwwDir' => TEST_DIR,
+			])
+			->createContainer();
+	}
+
+}

--- a/tests/KdybyTests/Doctrine/Console/CommandTestCase.php
+++ b/tests/KdybyTests/Doctrine/Console/CommandTestCase.php
@@ -120,7 +120,7 @@ abstract class CommandTestCase extends Tester\TestCase
 	{
 		$config = new Nette\Configurator;
 		return $config->setTempDirectory(TEMP_DIR)
-			->addConfig(TEST_DIR . '/nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22')
+			->addConfig(TEST_DIR . '/nette-reset.' . (!isset($config->defaultExtensions['nette']) ? 'v23' : 'v22') . '.neon')
 			->addConfig(TEST_DIR . '/Doctrine/config/multiple-connections.neon')
 			->addParameters([
 				'appDir' => TEST_DIR,

--- a/tests/KdybyTests/Doctrine/Console/ConvertMappingCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/ConvertMappingCommand.phpt
@@ -23,20 +23,41 @@ require_once __DIR__ . '/../../bootstrap.php';
 class ConvertMappingCommandTest extends CommandTestCase
 {
 
-	public function testExportXML()
+	public function testDefaultConnectionExportXML()
 	{
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:convert-mapping', [
+		$destDir = TEMP_DIR . '/ConvertMappingCommandTest.default';
+
+		$applicationTester = $this->executeCommand('orm:convert-mapping', [
 			'to-type'   => 'xml',
-			'dest-path' => TEMP_DIR . '/ConvertMappingCommandTest',
+			'dest-path' => $destDir,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$entities as $entity) {
 			Assert::contains("Processing entity \"{$entity}\"", $output);
 		}
-		Assert::contains('Exporting "xml" mapping information to "' . realpath(TEMP_DIR) . '/ConvertMappingCommandTest"', $output);
+		Assert::notContains('Processing entity "KdybyTests\Doctrine\Models2\Foo"', $output);
+		Assert::contains('Exporting "xml" mapping information to "' . realpath($destDir) . '"', $output);
+	}
+
+
+
+	public function testSecondConnectionExportXML()
+	{
+		$destDir = TEMP_DIR . '/ConvertMappingCommandTest.remote';
+
+		$applicationTester = $this->executeCommand('orm:convert-mapping', [
+			'to-type'   => 'xml',
+			'dest-path' => $destDir,
+			'--em'      => 'remote',
+		]);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::notContains('Processing entity "' . self::$entities[0] . '"', $output);
+		Assert::contains('Processing entity "KdybyTests\Doctrine\Models2\Foo"', $output);
+		Assert::contains('Exporting "xml" mapping information to "' . realpath($destDir) . '"', $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/ConvertMappingCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/ConvertMappingCommand.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\ConvertMappingCommand.
+ *
+ * @testCase Kdyby\Doctrine\Console\ConvertMappingCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class ConvertMappingCommandTest extends CommandTestCase
+{
+
+	public function testExportXML()
+	{
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:convert-mapping', [
+			'to-type'   => 'xml',
+			'dest-path' => TEMP_DIR . '/ConvertMappingCommandTest',
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$entities as $entity) {
+			Assert::contains("Processing entity \"{$entity}\"", $output);
+		}
+		Assert::contains('Exporting "xml" mapping information to "' . realpath(TEMP_DIR) . '/ConvertMappingCommandTest"', $output);
+	}
+
+}
+
+\run(new ConvertMappingCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/GenerateEntitiesCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/GenerateEntitiesCommand.phpt
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\GenerateEntitiesCommand.
+ *
+ * @testCase Kdyby\Doctrine\Console\GenerateEntitiesCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class GenerateEntitiesCommandTest extends CommandTestCase
+{
+
+	public function testExportEntities()
+	{
+		FileSystem::createDir(TEMP_DIR . '/GenerateEntitiesCommandTest');
+
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:generate-entities', [
+			'dest-path' => TEMP_DIR . '/GenerateEntitiesCommandTest',
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$entities as $entity) {
+			Assert::contains("Processing entity \"{$entity}\"", $output);
+		}
+		Assert::contains('Entity classes generated to "' . realpath(TEMP_DIR) . '/GenerateEntitiesCommandTest"', $output);
+	}
+
+}
+
+\run(new GenerateEntitiesCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/GenerateEntitiesCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/GenerateEntitiesCommand.phpt
@@ -24,21 +24,41 @@ require_once __DIR__ . '/../../bootstrap.php';
 class GenerateEntitiesCommandTest extends CommandTestCase
 {
 
-	public function testExportEntities()
+	public function testDefaultConnectionExportEntities()
 	{
-		FileSystem::createDir(TEMP_DIR . '/GenerateEntitiesCommandTest');
+		$destDir = TEMP_DIR . '/GenerateEntitiesCommandTest.default';
+		FileSystem::createDir($destDir);
 
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:generate-entities', [
-			'dest-path' => TEMP_DIR . '/GenerateEntitiesCommandTest',
+		$applicationTester = $this->executeCommand('orm:generate-entities', [
+			'dest-path' => $destDir,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$entities as $entity) {
 			Assert::contains("Processing entity \"{$entity}\"", $output);
 		}
-		Assert::contains('Entity classes generated to "' . realpath(TEMP_DIR) . '/GenerateEntitiesCommandTest"', $output);
+		Assert::notContains('Processing entity "KdybyTests\Doctrine\Models2\Foo"', $output);
+		Assert::contains('Entity classes generated to "' . realpath($destDir) . '"', $output);
+	}
+
+
+
+	public function testSecondConnectionExportEntities()
+	{
+		$destDir = TEMP_DIR . '/GenerateEntitiesCommandTest.remote';
+		FileSystem::createDir($destDir);
+
+		$applicationTester = $this->executeCommand('orm:generate-entities', [
+			'dest-path' => $destDir,
+			'--em'      => 'remote',
+		]);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::notContains('Processing entity "' . self::$entities[0] . '"', $output);
+		Assert::contains('Processing entity "KdybyTests\Doctrine\Models2\Foo"', $output);
+		Assert::contains('Entity classes generated to "' . realpath($destDir) . '"', $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/GenerateProxiesCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/GenerateProxiesCommand.phpt
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\GenerateProxiesCommand.
+ *
+ * @testCase Kdyby\Doctrine\Console\GenerateProxiesCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class GenerateProxiesCommandTest extends CommandTestCase
+{
+
+	public function testExportEntities()
+	{
+		FileSystem::createDir(TEMP_DIR . '/GenerateProxiesCommandTest');
+
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:generate-proxies', [
+			'dest-path' => TEMP_DIR . '/GenerateProxiesCommandTest',
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$entities as $entity) {
+			Assert::contains("Processing entity \"{$entity}\"", $output);
+		}
+		Assert::contains('Proxy classes generated to "' . realpath(TEMP_DIR) . '/GenerateProxiesCommandTest"', $output);
+	}
+
+}
+
+\run(new GenerateProxiesCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/GenerateProxiesCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/GenerateProxiesCommand.phpt
@@ -24,21 +24,41 @@ require_once __DIR__ . '/../../bootstrap.php';
 class GenerateProxiesCommandTest extends CommandTestCase
 {
 
-	public function testExportEntities()
+	public function testDefaultConnectionExportEntities()
 	{
-		FileSystem::createDir(TEMP_DIR . '/GenerateProxiesCommandTest');
+		$destDir = TEMP_DIR . '/GenerateProxiesCommandTest.default';
+		FileSystem::createDir($destDir);
 
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:generate-proxies', [
-			'dest-path' => TEMP_DIR . '/GenerateProxiesCommandTest',
+		$applicationTester = $this->executeCommand('orm:generate-proxies', [
+			'dest-path' => $destDir,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$entities as $entity) {
 			Assert::contains("Processing entity \"{$entity}\"", $output);
 		}
-		Assert::contains('Proxy classes generated to "' . realpath(TEMP_DIR) . '/GenerateProxiesCommandTest"', $output);
+		Assert::notContains('Processing entity "KdybyTests\Doctrine\Models2\Foo"', $output);
+		Assert::contains('Proxy classes generated to "' . realpath($destDir) . '"', $output);
+	}
+
+
+
+	public function testSecondConnectionExportEntities()
+	{
+		$destDir = TEMP_DIR . '/GenerateProxiesCommandTest.remote';
+		FileSystem::createDir($destDir);
+
+		$applicationTester = $this->executeCommand('orm:generate-proxies', [
+			'dest-path' => $destDir,
+			'--em'      => 'remote',
+		]);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::notContains('Processing entity "' . self::$entities[0] . '"', $output);
+		Assert::contains('Processing entity "KdybyTests\Doctrine\Models2\Foo"', $output);
+		Assert::contains('Proxy classes generated to "' . realpath($destDir) . '"', $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/InfoCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/InfoCommand.phpt
@@ -23,16 +23,28 @@ require_once __DIR__ . '/../../bootstrap.php';
 class ValidateSchemaCommandTest extends CommandTestCase
 {
 
-	public function testInfo()
+	public function testDefaultConnectionInfo()
 	{
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:info');
+		$applicationTester = $this->executeCommand('orm:info');
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$entities as $entity) {
 			Assert::contains("[OK]   {$entity}", $output);
 		}
+		Assert::notContains('[OK]   KdybyTests\Doctrine\Models2\Foo', $output);
+	}
+
+
+
+	public function testSecondConnectionInfo()
+	{
+		$applicationTester = $this->executeCommand('orm:info', ['--em' => 'remote']);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::contains('[OK]   KdybyTests\Doctrine\Models2\Foo', $output);
+		Assert::notContains('[OK]   ' . self::$entities[0], $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/InfoCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/InfoCommand.phpt
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\ValidateSchemaCommand.
+ *
+ * @testCase Kdyby\Doctrine\Console\ValidateSchemaCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class ValidateSchemaCommandTest extends CommandTestCase
+{
+
+	public function testInfo()
+	{
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:info');
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$entities as $entity) {
+			Assert::contains("[OK]   {$entity}", $output);
+		}
+	}
+
+}
+
+\run(new ValidateSchemaCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/SchemaCreateCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/SchemaCreateCommand.phpt
@@ -23,18 +23,33 @@ require_once __DIR__ . '/../../bootstrap.php';
 class SchemaCreateCommandTest extends CommandTestCase
 {
 
-	public function testDumpSQL()
+	public function testDefaultConnectionDumpSQL()
 	{
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:schema-tool:create', [
+		$applicationTester = $this->executeCommand('orm:schema-tool:create', [
 			'--dump-sql' => TRUE,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$tables as $table) {
 			Assert::contains("CREATE TABLE {$table}", $output);
 		}
+		Assert::notContains('CREATE TABLE model2_foo', $output);
+	}
+
+
+
+	public function testSecondConnectionDumpSQL()
+	{
+		$applicationTester = $this->executeCommand('orm:schema-tool:create', [
+			'--dump-sql' => TRUE,
+			'--em'       => 'remote',
+		]);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::contains("CREATE TABLE model2_foo", $output);
+		Assert::notContains('CREATE TABLE ' . self::$tables[0], $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/SchemaCreateCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/SchemaCreateCommand.phpt
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\SchemaCreateCommand.
+ *
+ * @testCase Kdyby\Doctrine\Console\SchemaCreateCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class SchemaCreateCommandTest extends CommandTestCase
+{
+
+	public function testDumpSQL()
+	{
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:schema-tool:create', [
+			'--dump-sql' => TRUE,
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$tables as $table) {
+			Assert::contains("CREATE TABLE {$table}", $output);
+		}
+	}
+
+}
+
+\run(new SchemaCreateCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/SchemaDropCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/SchemaDropCommand.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\SchemaDropCommand
+ *
+ * @testCase Kdyby\Doctrine\Console\SchemaDropCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class SchemaDropCommandTest extends CommandTestCase
+{
+
+	public function testDumpSQL()
+	{
+		$this->executeCommand('orm:schema-tool:create');
+
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:schema-tool:drop', [
+			'--dump-sql' => TRUE,
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$tables as $table) {
+			Assert::contains("DROP TABLE {$table}", $output);
+		}
+	}
+
+}
+
+\run(new SchemaDropCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/SchemaDropCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/SchemaDropCommand.phpt
@@ -23,20 +23,37 @@ require_once __DIR__ . '/../../bootstrap.php';
 class SchemaDropCommandTest extends CommandTestCase
 {
 
-	public function testDumpSQL()
+	public function testDefaultConnectionDumpSQL()
 	{
 		$this->executeCommand('orm:schema-tool:create');
 
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:schema-tool:drop', [
+		$applicationTester = $this->executeCommand('orm:schema-tool:drop', [
 			'--dump-sql' => TRUE,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$tables as $table) {
 			Assert::contains("DROP TABLE {$table}", $output);
 		}
+		Assert::notContains('DROP TABLE model2_foo', $output);
+	}
+
+
+
+	public function testSecondConnectionDumpSQL()
+	{
+		$this->executeCommand('orm:schema-tool:create', ['--em' => 'remote']);
+
+		$applicationTester = $this->executeCommand('orm:schema-tool:drop', [
+			'--dump-sql' => TRUE,
+			'--em'       => 'remote',
+		]);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::contains("DROP TABLE model2_foo", $output);
+		Assert::notContains('DROP TABLE ' . self::$tables[0], $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/SchemaUpdateCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/SchemaUpdateCommand.phpt
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\SchemaUpdateCommand
+ *
+ * @testCase Kdyby\Doctrine\Console\SchemaUpdateCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class SchemaUpdateCommandTest extends CommandTestCase
+{
+
+	public function testDumpSQL()
+	{
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:schema-tool:update', [
+			'--dump-sql' => TRUE,
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		foreach (self::$tables as $table) {
+			Assert::contains("CREATE TABLE {$table}", $output);
+		}
+	}
+
+}
+
+\run(new SchemaUpdateCommandTest());

--- a/tests/KdybyTests/Doctrine/Console/SchemaUpdateCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/SchemaUpdateCommand.phpt
@@ -23,18 +23,33 @@ require_once __DIR__ . '/../../bootstrap.php';
 class SchemaUpdateCommandTest extends CommandTestCase
 {
 
-	public function testDumpSQL()
+	public function testDefaultConnectionDumpSQL()
 	{
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:schema-tool:update', [
+		$applicationTester = $this->executeCommand('orm:schema-tool:update', [
 			'--dump-sql' => TRUE,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
 
 		foreach (self::$tables as $table) {
 			Assert::contains("CREATE TABLE {$table}", $output);
 		}
+		Assert::notContains('CREATE TABLE model2_foo', $output);
+	}
+
+
+
+	public function testSecondConnectionDumpSQL()
+	{
+		$applicationTester = $this->executeCommand('orm:schema-tool:update', [
+			'--dump-sql' => TRUE,
+			'--em'       => 'remote',
+		]);
+
+		$output = $applicationTester->getDisplay();
+
+		Assert::contains("CREATE TABLE model2_foo", $output);
+		Assert::notContains('CREATE TABLE ' . self::$tables[0], $output);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Console/ValidateSchemaCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/ValidateSchemaCommand.phpt
@@ -19,18 +19,35 @@ require_once __DIR__ . '/../../bootstrap.php';
 
 /**
  * @author Tomáš Jacík <tomas@jacik.cz>
+ *
+ * TODO: Output of both tests is the same. Solutions is to call orm:schema-tool:create command
+ * and don't skip sync to check if each connection is in sync with own schema. For some reason
+ * it's not working with sqlite in memory.
  */
 class ValidateSchemaCommandTest extends CommandTestCase
 {
 
-	public function testCheckMapping()
+	public function testDefaultConnectionCheckMapping()
 	{
-		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
-		$commandTester = $this->executeCommand('orm:validate-schema', [
+		$applicationTester = $this->executeCommand('orm:validate-schema', [
 			'--skip-sync' => TRUE,
 		]);
 
-		$output = $commandTester->getDisplay();
+		$output = $applicationTester->getDisplay();
+
+		Assert::contains('[Mapping]  OK - The mapping files are correct.', $output);
+	}
+
+
+
+	public function testSecondConnectionCheckMapping()
+	{
+		$applicationTester = $this->executeCommand('orm:validate-schema', [
+			'--skip-sync' => TRUE,
+			'--em'        => 'remote'
+		]);
+
+		$output = $applicationTester->getDisplay();
 
 		Assert::contains('[Mapping]  OK - The mapping files are correct.', $output);
 	}

--- a/tests/KdybyTests/Doctrine/Console/ValidateSchemaCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/ValidateSchemaCommand.phpt
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test: Kdyby\Doctrine\Console\ValidateSchemaCommand.
+ *
+ * @testCase Kdyby\Doctrine\Console\ValidateSchemaCommandTest
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ * @package Kdyby\Doctrine
+ */
+
+namespace KdybyTests\Doctrine\Console;
+
+use Nette\Utils\Strings;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class ValidateSchemaCommandTest extends CommandTestCase
+{
+
+	public function testCheckMapping()
+	{
+		/** @var \Symfony\Component\Console\Tester\CommandTester $commandTester */
+		$commandTester = $this->executeCommand('orm:validate-schema', [
+			'--skip-sync' => TRUE,
+		]);
+
+		$output = $commandTester->getDisplay();
+
+		Assert::contains('[Mapping]  OK - The mapping files are correct.', $output);
+	}
+
+}
+
+\run(new ValidateSchemaCommandTest());

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -146,10 +146,10 @@ class ExtensionTest extends Tester\TestCase
 
 	private static function runExternalScript($script, array $args, array $env)
 	{
-		static $spec = array(
-			1 => array('pipe', 'w'),
-			2 => array('pipe', 'w'),
-		);
+		static $spec = [
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
 		$cmd = sprintf('php %s %s', escapeshellarg(basename($script)), implode(' ', array_map('escapeshellarg', $args)));
 		$process = proc_open($cmd, $spec, $pipes, dirname($script), $env);
 

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -36,7 +36,7 @@ class ExtensionTest extends Tester\TestCase
 		$config->setTempDirectory(TEMP_DIR);
 		$config->addParameters(['container' => ['class' => 'SystemContainer_' . md5($configFile)]]);
 		$config->addParameters(['appDir' => $rootDir = __DIR__ . '/..', 'wwwDir' => $rootDir]);
-		$config->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+		$config->addConfig(__DIR__ . '/../nette-reset.' . (!isset($config->defaultExtensions['nette']) ? 'v23' : 'v22') . '.neon');
 		$config->addConfig(__DIR__ . '/config/' . $configFile . '.neon');
 
 		return $config->createContainer();

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -32,8 +32,6 @@ class ExtensionTest extends Tester\TestCase
 	 */
 	public function createContainer($configFile)
 	{
-		require_once __DIR__ . '/models/cms.php';
-
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
 		$config->addParameters(['container' => ['class' => 'SystemContainer_' . md5($configFile)]]);
@@ -123,6 +121,45 @@ class ExtensionTest extends Tester\TestCase
 			$container->getService('kdyby.doctrine.registry')->getConnection('remote'),
 			$container->getByType('KdybyTests\DoctrineMocks\RemoteEntityManager')->getConnection()
 		);
+	}
+
+
+
+	public function testProxyAutoloading()
+	{
+		$env = ['TEMP_DIR' => $scriptTempDir = TEMP_DIR . '/script'];
+		Nette\Utils\FileSystem::createDir($scriptTempDir . '/cache');
+		Nette\Utils\FileSystem::createDir($scriptTempDir . '/sessions');
+
+		$compileOutput = explode("\n", self::runExternalScript(__DIR__ . '/proxies-sessions-test/run.php', ['compile'], $env), 2);
+		Assert::same('compiled,proxies generated,schema generated', $compileOutput[0]);
+		$env['SESSION_ID'] = $sessionId = $compileOutput[1];
+
+		$storeOutput = self::runExternalScript(__DIR__ . '/proxies-sessions-test/run.php', ['store'], $env);
+		Assert::match('Kdyby\GeneratedProxy\__CG__\KdybyTests\Doctrine\CmsOrder %A%id => 1%A%status => "new"%A%', $storeOutput);
+
+		$runOutput = self::runExternalScript(__DIR__ . '/proxies-sessions-test/run.php', ['read'], $env);
+		Assert::match('Kdyby\GeneratedProxy\__CG__\KdybyTests\Doctrine\CmsOrder %A%id => 1%A%status => "new"%A%', $runOutput);
+	}
+
+
+
+	private static function runExternalScript($script, array $args, array $env)
+	{
+		static $spec = array(
+			1 => array('pipe', 'w'),
+			2 => array('pipe', 'w'),
+		);
+		$cmd = sprintf('php %s %s', escapeshellarg(basename($script)), implode(' ', array_map('escapeshellarg', $args)));
+		$process = proc_open($cmd, $spec, $pipes, dirname($script), $env);
+
+		$output = stream_get_contents($pipes[1]); // wait for process
+		$error = stream_get_contents($pipes[2]);
+		if (proc_close($process) > 0) {
+			throw new \RuntimeException($error . "\n" . $output);
+		}
+
+		return $output;
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -109,6 +109,22 @@ class ExtensionTest extends Tester\TestCase
 		], $entityClasses);
 	}
 
+
+
+	public function testInheritance()
+	{
+		$container = $this->createContainer('entitymanager-decorator');
+
+		Assert::same(
+			$container->getService('kdyby.doctrine.registry')->getConnection('default'),
+			$container->getByType('Kdyby\Doctrine\EntityManager')->getConnection()
+		);
+		Assert::same(
+			$container->getService('kdyby.doctrine.registry')->getConnection('remote'),
+			$container->getByType('KdybyTests\DoctrineMocks\RemoteEntityManager')->getConnection()
+		);
+	}
+
 }
 
 \run(new ExtensionTest());

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -127,7 +127,7 @@ class ExtensionTest extends Tester\TestCase
 
 	public function testProxyAutoloading()
 	{
-		$env = ['TEMP_DIR' => $scriptTempDir = TEMP_DIR . '/script'];
+		$env = $_ENV + ['TEMP_DIR' => $scriptTempDir = TEMP_DIR . '/script'];
 		Nette\Utils\FileSystem::createDir($scriptTempDir . '/cache');
 		Nette\Utils\FileSystem::createDir($scriptTempDir . '/sessions');
 

--- a/tests/KdybyTests/Doctrine/MagicAccesors.phpt
+++ b/tests/KdybyTests/Doctrine/MagicAccesors.phpt
@@ -383,6 +383,23 @@ class MagicAccessorsTest extends Tester\TestCase
 		Assert::same(2, $entity->getRealSomething());
 	}
 
+
+
+	public function testPluralAccessor()
+	{
+		$entity = new BadlyNamedEntity();
+		Assert::false($entity->hasBus(1));
+
+		$entity->addBus(1);
+		$entity->addBus(2);
+		Assert::true($entity->hasBus(1));
+
+		$entity->removeBus(1);
+		Assert::false($entity->hasBus(1));
+
+		Assert::true($entity->hasBus(2));
+	}
+
 }
 
 
@@ -426,6 +443,11 @@ class BadlyNamedEntity
 	protected $four;
 
 	/**
+	 * @var \Doctrine\Common\Collections\ArrayCollection
+	 */
+	protected $buses;
+
+	/**
 	 * @var object
 	 */
 	public $three;
@@ -457,8 +479,6 @@ class BadlyNamedEntity
 
 
 
-	/**
-	 */
 	public function __construct()
 	{
 		$this->one = (object) ['id' => 1];
@@ -469,6 +489,8 @@ class BadlyNamedEntity
 		$this->twos = new ArrayCollection([(object) ['id' => 2]]);
 		$this->proxies = new ArrayCollection([(object) ['id' => 3]]);
 		$this->threes = new ArrayCollection([(object) ['id' => 4]]);
+
+		$this->buses = new ArrayCollection();
 	}
 
 

--- a/tests/KdybyTests/Doctrine/NonLockingUniqueInserter.phpt
+++ b/tests/KdybyTests/Doctrine/NonLockingUniqueInserter.phpt
@@ -70,7 +70,6 @@ class NonLockingUniqueInserterTest extends KdybyTests\Doctrine\ORMTestCase
 	public function testSavingRelations()
 	{
 		$em = $this->createMemoryManager();
-		$em->getProxyFactory()->generateProxyClasses($em->getMetadataFactory()->getAllMetadata());
 
 		$user = new CmsUser();
 		$user->username = 'HosipLan';

--- a/tests/KdybyTests/Doctrine/ORMTestCase.php
+++ b/tests/KdybyTests/Doctrine/ORMTestCase.php
@@ -42,7 +42,7 @@ abstract class ORMTestCase extends Tester\TestCase
 
 		$config = new Nette\Configurator();
 		$container = $config->setTempDirectory(TEMP_DIR)
-			->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22')
+			->addConfig(__DIR__ . '/../nette-reset.' . (!isset($config->defaultExtensions['nette']) ? 'v23' : 'v22') . '.neon')
 			->addConfig(__DIR__ . '/config/memory.neon')
 			->addParameters([
 				'appDir' => $rootDir,

--- a/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
+++ b/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
@@ -37,7 +37,7 @@ class RepositoryFactoryTest extends Tester\TestCase
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
 		$config->addParameters(['appDir' => $rootDir = __DIR__ . '/..', 'wwwDir' => $rootDir]);
-		$config->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+		$config->addConfig(__DIR__ . '/../nette-reset.' . (!isset($config->defaultExtensions['nette']) ? 'v23' : 'v22') . '.neon');
 		$config->addConfig(__DIR__ . '/config/' . $configFile . '.neon');
 
 		return $config->createContainer();

--- a/tests/KdybyTests/Doctrine/TargetEntityMapping.phpt
+++ b/tests/KdybyTests/Doctrine/TargetEntityMapping.phpt
@@ -13,6 +13,7 @@ namespace KdybyTests\Doctrine;
 use Doctrine;
 use Kdyby;
 use KdybyTests;
+use Kdyby\Doctrine\Events;
 use Nette;
 use Tester;
 use Tester\Assert;
@@ -56,6 +57,50 @@ class TargetEntityMapping extends KdybyTests\Doctrine\ORMTestCase
 		Assert::same('KdybyTests\Doctrine\CmsAddress', $meta->name);
 	}
 
+	public function testListenersExists()
+	{
+		$evm = $this->serviceLocator->getByType('Kdyby\Events\EventManager');
+		$loadClassMetadata = $evm->getListeners(Events::loadClassMetadata);
+		$onClassMetadataNotFound = $evm->getListeners(Events::onClassMetadataNotFound);
+
+		$filterRTEL = function ($items) {
+			return array_filter($items, function($item){
+				return $item instanceof Kdyby\Doctrine\Tools\ResolveTargetEntityListener;
+			});
+		};
+		Assert::count(1, $filterRTEL($loadClassMetadata));
+		Assert::count(1, $filterRTEL($onClassMetadataNotFound));
+	}
+
+	public function testIsCalledOnMetadataNotNotFound()
+	{
+		//because all metadata are loaded in ORMTestCase
+		$this->em->getMetadataFactory()->setMetadataFor('KdybyTests\Doctrine\ICmsAddress', NULL);
+
+		$eventPanel = new EventPanelMock();
+		$evm = $this->serviceLocator->getByType('Kdyby\Events\EventManager');
+		$evm->setPanel($eventPanel);
+
+		$this->em->getClassMetadata('KdybyTests\Doctrine\ICmsAddress');
+
+		Assert::same(Events::onClassMetadataNotFound, $eventPanel->calledEvents[0]);
+	}
+}
+
+
+class EventPanelMock extends Kdyby\Events\Diagnostics\Panel
+{
+	public $calledEvents = [];
+
+	public function __construct()
+	{
+
+	}
+
+	public function eventDispatch($eventName, Doctrine\Common\EventArgs $args = NULL)
+	{
+		$this->calledEvents[] = $eventName;
+	}
 }
 
 

--- a/tests/KdybyTests/Doctrine/config/entitymanager-decorator.neon
+++ b/tests/KdybyTests/Doctrine/config/entitymanager-decorator.neon
@@ -1,0 +1,15 @@
+kdyby.doctrine:
+	metadata:
+		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
+
+	default:
+		driver: pdo_sqlite
+		memory: true
+
+	remote:
+		driver: pdo_sqlite
+		memory: true
+
+
+services:
+	- KdybyTests\DoctrineMocks\RemoteEntityManager(@kdyby.doctrine.remote.entityManager)

--- a/tests/KdybyTests/Doctrine/config/multiple-connections.neon
+++ b/tests/KdybyTests/Doctrine/config/multiple-connections.neon
@@ -1,11 +1,12 @@
 kdyby.doctrine:
-	metadata:
-		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
-
 	default:
 		driver: pdo_sqlite
 		memory: true
+		metadata:
+			KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
 
 	remote:
 		driver: pdo_sqlite
 		memory: true
+		metadata:
+			KdybyTests\Doctrine\Models2: annotations(%appDir%/Doctrine/models2)

--- a/tests/KdybyTests/Doctrine/config/proxiesSessionAutoloading.neon
+++ b/tests/KdybyTests/Doctrine/config/proxiesSessionAutoloading.neon
@@ -1,0 +1,8 @@
+console:
+	disabled: true
+
+kdyby.doctrine:
+	driver: pdo_sqlite
+	path: %tempDir%/db.sqlite
+	metadata:
+		KdybyTests\Doctrine: annotations(%appDir%/../models)

--- a/tests/KdybyTests/Doctrine/models/cms.php
+++ b/tests/KdybyTests/Doctrine/models/cms.php
@@ -296,7 +296,7 @@ class CmsPhoneNumber
 	public $phoneNumber;
 
 	/**
-	 * @ORM\ManyToOne(targetEntity="CmsUser", inversedBy="phonenumbers", cascade={"merge"})
+	 * @ORM\ManyToOne(targetEntity="CmsUser", inversedBy="phoneNumbers", cascade={"merge"})
 	 * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
 	 */
 	public $user;

--- a/tests/KdybyTests/Doctrine/models/cms.php
+++ b/tests/KdybyTests/Doctrine/models/cms.php
@@ -478,4 +478,11 @@ class CmsOrder
 	 */
 	public $status;
 
+
+
+	public function dummyMethodForProxyInitialize()
+	{
+
+	}
+
 }

--- a/tests/KdybyTests/Doctrine/models2/Foo.php
+++ b/tests/KdybyTests/Doctrine/models2/Foo.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace KdybyTests\Doctrine\Models2;
+
+use Doctrine\ORM\Mapping as ORM;
+
+
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="model2_foo")
+ */
+class Foo
+{
+
+	/**
+	 * @ORM\Column(type="integer")
+	 * @ORM\Id @ORM\GeneratedValue
+	 */
+	public $id;
+
+	/**
+	 * @ORM\Column(length=50)
+	 */
+	public $name;
+
+}

--- a/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
+++ b/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
@@ -9,6 +9,8 @@ if (PHP_SAPI !== 'cli') {
 	exit(1);
 }
 
+\Tracy\Debugger::enable(FALSE, getenv('TEMP_DIR'));
+
 if ($sessionId = getenv('SESSION_ID')) {
 	$GLOBALS['_COOKIE'][session_name()] = $sessionId;
 }

--- a/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
+++ b/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
@@ -23,7 +23,6 @@ $config->addConfig(__DIR__ . '/../../nette-reset.neon', !isset($config->defaultE
 $config->addConfig(__DIR__ . '/../config/proxiesSessionAutoloading.neon');
 
 $container = $config->createContainer();
-//$container->addService('')
 
 // requires disabled autostart
 $session = $container->getByType('Nette\Http\Session');

--- a/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
+++ b/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
@@ -21,7 +21,7 @@ $config->addParameters([
 	'appDir' => __DIR__,
 	'wwwDir' => __DIR__,
 ]);
-$config->addConfig(__DIR__ . '/../../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+$config->addConfig(__DIR__ . '/../../nette-reset.' . (!isset($config->defaultExtensions['nette']) ? 'v23' : 'v22') . '.neon');
 $config->addConfig(__DIR__ . '/../config/proxiesSessionAutoloading.neon');
 
 $container = $config->createContainer();

--- a/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
+++ b/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
@@ -1,0 +1,73 @@
+<?php
+
+use KdybyTests\Doctrine\CmsOrder;
+
+require_once __DIR__ . '/../../../../vendor/autoload.php';
+
+if (PHP_SAPI !== 'cli') {
+	echo "wrong sapi, srybro\n";
+	exit(1);
+}
+
+if ($sessionId = getenv('SESSION_ID')) {
+	$GLOBALS['_COOKIE'][session_name()] = $sessionId;
+}
+
+$config = new Nette\Configurator();
+$config->setTempDirectory(getenv('TEMP_DIR'));
+$config->addParameters([
+	'appDir' => __DIR__,
+	'wwwDir' => __DIR__,
+]);
+$config->addConfig(__DIR__ . '/../../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+$config->addConfig(__DIR__ . '/../config/proxiesSessionAutoloading.neon');
+
+$container = $config->createContainer();
+//$container->addService('')
+
+// requires disabled autostart
+$session = $container->getByType('Nette\Http\Session');
+
+if ($_SERVER['argv'][1] === 'compile') {
+	$session->start();
+
+	$em = $container->getByType('Doctrine\ORM\EntityManager');
+	$allMetadata = $em->getMetadataFactory()->getAllMetadata();
+	echo 'compiled,';
+
+	$em->getProxyFactory()->generateProxyClasses($allMetadata);
+	echo 'proxies generated,';
+
+	$schemaTool = $container->getByType('Doctrine\ORM\Tools\SchemaTool');
+	$schemaTool->createSchema($allMetadata);
+	echo "schema generated\n";
+
+	echo $session->getId();
+
+} elseif ($_SERVER['argv'][1] === 'store') {
+	$session->start();
+
+	$em = $container->getByType('Doctrine\ORM\EntityManager');
+
+	$em->persist($order = new CmsOrder());
+	$order->status = 'new';
+	$em->flush();
+	$orderId = $order->id;
+	$em->clear();
+
+	$orderSession = $session->getSection('order');
+	/** @var KdybyTests\Doctrine\CmsOrder $proxy */
+	$proxy = $em->getReference('KdybyTests\Doctrine\CmsOrder', $orderId);
+	$proxy->dummyMethodForProxyInitialize();
+	$orderSession->entity = $proxy;
+
+	echo \Tracy\Dumper::toText($proxy);
+
+} elseif ($_SERVER['argv'][1] === 'read') {
+	$session->start();
+
+	$orderSession = $session->getSection('order');
+	echo \Tracy\Dumper::toText($orderSession->entity);
+}
+
+$session->close();

--- a/tests/KdybyTests/DoctrineMocks/RemoteEntityManager.php
+++ b/tests/KdybyTests/DoctrineMocks/RemoteEntityManager.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace KdybyTests\DoctrineMocks;
+
+
+
+/**
+ * @author Tomáš Jacík <tomas@jacik.cz>
+ */
+class RemoteEntityManager extends \Doctrine\ORM\Decorator\EntityManagerDecorator
+{
+}

--- a/tests/KdybyTests/bootstrap.php
+++ b/tests/KdybyTests/bootstrap.php
@@ -19,8 +19,9 @@ Tester\Environment::setup();
 class_alias('Tester\Assert', 'Assert');
 date_default_timezone_set('Europe/Prague');
 
-// create temporary directory
+define('TEST_DIR', __DIR__);
 define('TEMP_DIR', __DIR__ . '/../tmp/' . (isset($_SERVER['argv']) ? md5(serialize($_SERVER['argv'])) : getmypid()));
+// create temporary directory
 Tester\Helpers::purge(TEMP_DIR);
 
 

--- a/tests/KdybyTests/bootstrap.php
+++ b/tests/KdybyTests/bootstrap.php
@@ -30,7 +30,6 @@ $_SERVER = array_intersect_key($_SERVER, array_flip([
 ]));
 $_SERVER['REQUEST_TIME'] = 1234567890;
 $_GET = $_POST = [];
-$_ENV = array_intersect_key($_ENV, ['TRAVIS' => TRUE]);
 
 function id($val) {
 	return $val;

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -33,6 +33,7 @@ v22 < common:
 
 		session:
 			autoStart: false
+			save_path: %tempDir%/sessions
 
 v23 < common:
 	http:
@@ -40,3 +41,4 @@ v23 < common:
 
 	session:
 		autoStart: false
+		save_path: %tempDir%/sessions

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -1,44 +1,25 @@
-common:
-	php:
-		date.timezone: Europe/Prague
+php:
+	date.timezone: Europe/Prague
 
 
-	extensions:
-		events: Kdyby\Events\DI\EventsExtension
-		console: Kdyby\Console\DI\ConsoleExtension
-		annotations: Kdyby\Annotations\DI\AnnotationsExtension
-		kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
+extensions:
+	events: Kdyby\Events\DI\EventsExtension
+	console: Kdyby\Console\DI\ConsoleExtension
+	annotations: Kdyby\Annotations\DI\AnnotationsExtension
+	kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
 
 
-	kdyby.doctrine:
-		metadataCache: array
-		queryCache: array
-		resultCache: array
-		hydrationCache: array
+kdyby.doctrine:
+	metadataCache: array
+	queryCache: array
+	resultCache: array
+	hydrationCache: array
 
 
-	console:
-		url: http://www.kdyby.org/
+console:
+	url: http://www.kdyby.org/
 
 
-	services:
-		cacheStorage:
-			class: Nette\Caching\Storages\MemoryStorage
-
-
-v22 < common:
-	nette:
-		security:
-			frames: null
-
-		session:
-			autoStart: false
-			save_path: %tempDir%/sessions
-
-v23 < common:
-	http:
-		frames: null
-
-	session:
-		autoStart: false
-		save_path: %tempDir%/sessions
+services:
+	cacheStorage:
+		class: Nette\Caching\Storages\MemoryStorage

--- a/tests/KdybyTests/nette-reset.v22.neon
+++ b/tests/KdybyTests/nette-reset.v22.neon
@@ -1,0 +1,10 @@
+includes:
+	- nette-reset.neon
+
+nette:
+	security:
+		frames: null
+
+	session:
+		autoStart: false
+		save_path: %tempDir%/sessions

--- a/tests/KdybyTests/nette-reset.v23.neon
+++ b/tests/KdybyTests/nette-reset.v23.neon
@@ -1,0 +1,9 @@
+includes:
+	- nette-reset.neon
+
+http:
+	frames: null
+
+session:
+	autoStart: false
+	save_path: %tempDir%/sessions

--- a/tests/mysql.neon
+++ b/tests/mysql.neon
@@ -1,15 +1,6 @@
-common:
-	doctrine:
-		host: 127.0.0.1
-		user: root
-		charset: UTF8
-		driver: pdo_mysql
-
-
-travis < common:
-	doctrine:
-		password: ""
-
-localhost < common:
-	doctrine:
-		password: "heslo"
+doctrine:
+	host: 127.0.0.1
+	user: root
+	password: ""
+	charset: UTF8
+	driver: pdo_mysql


### PR DESCRIPTION
This PR should fix #230 . There was some kind of custom resolving metadata for target entity in ClassMetadataFactory, but Doctrine itself imho has better and faster resolving via onClassMetadataNotFound event. I tried it on local project and it is realy faster. Maybe there should be better tests for testing if is fired really this event during resolving, but I am not able to create it.
