### PR TITLE
MagicAccessors: empty ::__construct removed [Closes #254]

### DIFF
--- a/src/Kdyby/Doctrine/Entities/MagicAccessors.php
+++ b/src/Kdyby/Doctrine/Entities/MagicAccessors.php
@@ -40,14 +40,6 @@ trait MagicAccessors
 
 
 	/**
-	 */
-	public function __construct()
-	{
-	}
-
-
-
-	/**
 	 * @param string $property property name
 	 * @param array $args
 	 * @return Collection|array


### PR DESCRIPTION
The `__construct` method in MagicAccessors Trait is empty and causes problems with others Traits defining a constructor.

Closes #254 