### PR TITLE
Tests: Remove configuration sections

### DIFF
--- a/tests/KdybyTests/Doctrine/Console/CommandTestCase.php
+++ b/tests/KdybyTests/Doctrine/Console/CommandTestCase.php
@@ -120,7 +120,7 @@ abstract class CommandTestCase extends Tester\TestCase
 	{
 		$config = new Nette\Configurator;
 		return $config->setTempDirectory(TEMP_DIR)
-			->addConfig(TEST_DIR . '/nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22')
+			->addConfig(TEST_DIR . '/nette-reset.neon')
 			->addConfig(TEST_DIR . '/Doctrine/config/multiple-connections.neon')
 			->addParameters([
 				'appDir' => TEST_DIR,

--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -36,7 +36,7 @@ class ExtensionTest extends Tester\TestCase
 		$config->setTempDirectory(TEMP_DIR);
 		$config->addParameters(['container' => ['class' => 'SystemContainer_' . md5($configFile)]]);
 		$config->addParameters(['appDir' => $rootDir = __DIR__ . '/..', 'wwwDir' => $rootDir]);
-		$config->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+		$config->addConfig(__DIR__ . '/../nette-reset.neon');
 		$config->addConfig(__DIR__ . '/config/' . $configFile . '.neon');
 
 		return $config->createContainer();

--- a/tests/KdybyTests/Doctrine/ORMTestCase.php
+++ b/tests/KdybyTests/Doctrine/ORMTestCase.php
@@ -42,7 +42,7 @@ abstract class ORMTestCase extends Tester\TestCase
 
 		$config = new Nette\Configurator();
 		$container = $config->setTempDirectory(TEMP_DIR)
-			->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22')
+			->addConfig(__DIR__ . '/../nette-reset.neon')
 			->addConfig(__DIR__ . '/config/memory.neon')
 			->addParameters([
 				'appDir' => $rootDir,

--- a/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
+++ b/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
@@ -37,7 +37,7 @@ class RepositoryFactoryTest extends Tester\TestCase
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
 		$config->addParameters(['appDir' => $rootDir = __DIR__ . '/..', 'wwwDir' => $rootDir]);
-		$config->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+		$config->addConfig(__DIR__ . '/../nette-reset.neon');
 		$config->addConfig(__DIR__ . '/config/' . $configFile . '.neon');
 
 		return $config->createContainer();

--- a/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
+++ b/tests/KdybyTests/Doctrine/proxies-sessions-test/run.php
@@ -21,7 +21,7 @@ $config->addParameters([
 	'appDir' => __DIR__,
 	'wwwDir' => __DIR__,
 ]);
-$config->addConfig(__DIR__ . '/../../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+$config->addConfig(__DIR__ . '/../../nette-reset.neon');
 $config->addConfig(__DIR__ . '/../config/proxiesSessionAutoloading.neon');
 
 $container = $config->createContainer();

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -1,44 +1,34 @@
-common:
-	php:
-		date.timezone: Europe/Prague
+php:
+	date.timezone: Europe/Prague
 
 
-	extensions:
-		events: Kdyby\Events\DI\EventsExtension
-		console: Kdyby\Console\DI\ConsoleExtension
-		annotations: Kdyby\Annotations\DI\AnnotationsExtension
-		kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
+extensions:
+	events: Kdyby\Events\DI\EventsExtension
+	console: Kdyby\Console\DI\ConsoleExtension
+	annotations: Kdyby\Annotations\DI\AnnotationsExtension
+	kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
 
 
-	kdyby.doctrine:
-		metadataCache: array
-		queryCache: array
-		resultCache: array
-		hydrationCache: array
+kdyby.doctrine:
+	metadataCache: array
+	queryCache: array
+	resultCache: array
+	hydrationCache: array
 
 
-	console:
-		url: http://www.kdyby.org/
+console:
+	url: http://www.kdyby.org/
 
 
-	services:
-		cacheStorage:
-			class: Nette\Caching\Storages\MemoryStorage
+http:
+	frames: null
 
 
-v22 < common:
-	nette:
-		security:
-			frames: null
+session:
+	autoStart: false
+	save_path: %tempDir%/sessions
 
-		session:
-			autoStart: false
-			save_path: %tempDir%/sessions
 
-v23 < common:
-	http:
-		frames: null
-
-	session:
-		autoStart: false
-		save_path: %tempDir%/sessions
+services:
+	cacheStorage:
+		class: Nette\Caching\Storages\MemoryStorage


### PR DESCRIPTION
Some tests are currently failing with Nette 2.4 because of this error:

```
   Exited with error code 255 (expected 0)
   E_USER_DEPRECATED: Sections in config file are deprecated.
```