### PR TITLE
Evaluated Kdyby_Doctrine_IamTheKingOfHackingNette_* removed

### DIFF
--- a/src/Kdyby/Doctrine/DI/EntityLocator.php
+++ b/src/Kdyby/Doctrine/DI/EntityLocator.php
@@ -19,39 +19,57 @@ use Nette\DI\Container;
 class EntityLocator
 {
 
+	const CACHE_NS = 'Doctrine.EntityLocator';
+
+	/** @var Nette\Caching\Cache */
+	private $cache;
+
 	/** @var array */
 	private $map = [];
 
-	public function setup(Container $container, array $queue, array $classNames, array $managers)
+	public function __construct(Nette\Caching\IStorage $storage)
+	{
+		$this->cache = new Nette\Caching\Cache($storage, self::CACHE_NS);
+	}
+
+	public function setup(Container $container, $containerFile, array $queue, array $classNames, array $managers)
 	{
 		if (empty($queue)) {
 			return;
 		}
 
-		foreach ($queue as $manager => $items) {
-			$repository = $classNames[$manager];
-			/** @var Kdyby\Doctrine\EntityManager $entityManager */
-			$entityManager = $container->getService($managers[$manager]);
-			/** @var Doctrine\ORM\Mapping\ClassMetadata $entityMetadata */
-			$metadataFactory = $entityManager->getMetadataFactory();
+		$this->map = $this->cache->load($containerFile);
 
-			$allMetadata = [];
-			foreach ($metadataFactory->getAllMetadata() as $entityMetadata) {
-				if ($repository === $entityMetadata->customRepositoryClassName || empty($entityMetadata->customRepositoryClassName)) {
-					continue;
+		if ($this->map === NULL) {
+			foreach ($queue as $manager => $items) {
+				$repository = $classNames[$manager];
+				/** @var Kdyby\Doctrine\EntityManager $entityManager */
+				$entityManager = $container->getService($managers[$manager]);
+				/** @var Doctrine\ORM\Mapping\ClassMetadata $entityMetadata */
+				$metadataFactory = $entityManager->getMetadataFactory();
+
+				$allMetadata = [];
+				foreach ($metadataFactory->getAllMetadata() as $entityMetadata) {
+					if ($repository === $entityMetadata->customRepositoryClassName || empty($entityMetadata->customRepositoryClassName)) {
+						continue;
+					}
+
+					$allMetadata[ltrim($entityMetadata->customRepositoryClassName, '\\')] = $entityMetadata;
 				}
 
-				$allMetadata[ltrim($entityMetadata->customRepositoryClassName, '\\')] = $entityMetadata;
-			}
+				foreach ($items as $item) {
+					if (!isset($allMetadata[$item[0]])) {
+						throw new Nette\Utils\AssertionException(sprintf('Repository class %s have been found in DIC, but no entity has it assigned and it has no entity configured', $item[0]));
+					}
 
-			foreach ($items as $item) {
-				if (!isset($allMetadata[$item[0]])) {
-					throw new Nette\Utils\AssertionException(sprintf('Repository class %s have been found in DIC, but no entity has it assigned and it has no entity configured', $item[0]));
+					$entityMetadata = $allMetadata[$item[0]];
+					$this->map[$item[0]] = $entityMetadata->getName();
 				}
-
-				$entityMetadata = $allMetadata[$item[0]];
-				$this->map[$item[0]] = $entityMetadata->getName();
 			}
+
+			$this->cache->save($containerFile, $this->map, [
+				Nette\Caching\Cache::FILES => [$containerFile],
+			]);
 		}
 	}
 

--- a/src/Kdyby/Doctrine/DI/EntityLocator.php
+++ b/src/Kdyby/Doctrine/DI/EntityLocator.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ * Copyright (c) 2016 Jaroslav Hranička (hranicka@outlook.com)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace Kdyby\Doctrine\DI;
+
+use Doctrine;
+use Kdyby;
+use Nette;
+use Nette\DI\Container;
+
+class EntityLocator
+{
+
+	/** @var array */
+	private $map = [];
+
+	public function setup(Container $container, array $queue, array $classNames, array $managers)
+	{
+		if (empty($queue)) {
+			return;
+		}
+
+		foreach ($queue as $manager => $items) {
+			$repository = $classNames[$manager];
+			/** @var Kdyby\Doctrine\EntityManager $entityManager */
+			$entityManager = $container->getService($managers[$manager]);
+			/** @var Doctrine\ORM\Mapping\ClassMetadata $entityMetadata */
+			$metadataFactory = $entityManager->getMetadataFactory();
+
+			$allMetadata = [];
+			foreach ($metadataFactory->getAllMetadata() as $entityMetadata) {
+				if ($repository === $entityMetadata->customRepositoryClassName || empty($entityMetadata->customRepositoryClassName)) {
+					continue;
+				}
+
+				$allMetadata[ltrim($entityMetadata->customRepositoryClassName, '\\')] = $entityMetadata;
+			}
+
+			foreach ($items as $item) {
+				if (!isset($allMetadata[$item[0]])) {
+					throw new Nette\Utils\AssertionException(sprintf('Repository class %s have been found in DIC, but no entity has it assigned and it has no entity configured', $item[0]));
+				}
+
+				$entityMetadata = $allMetadata[$item[0]];
+				$this->map[$item[0]] = $entityMetadata->getName();
+			}
+		}
+	}
+
+	public function get($repositoryName)
+	{
+		if (isset($this->map[$repositoryName])) {
+			return $this->map[$repositoryName];
+		} else {
+			throw new Kdyby\Doctrine\InvalidArgumentException('Entity for repository %s was not found.', $repositoryName);
+		}
+	}
+
+}

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -782,7 +782,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			return $config['defaultRepositoryClassName'];
 		}, $this->managerConfigs);
 
-		$init->addBody('$this->getService(?)->setup($this, ?, ?, ?);', [
+		$init->addBody('$this->getService(?)->setup($this, __FILE__, ?, ?, ?);', [
 			$this->prefix('entityLocator'),
 			$this->postCompileRepositoriesQueue,
 			$classNames,

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -207,6 +207,10 @@ class OrmExtension extends Nette\DI\CompilerExtension
 				$builder->parameters[$this->name]['dbal']['defaultConnection'],
 				$builder->parameters[$this->name]['orm']['defaultEntityManager'],
 			]);
+
+		$builder->addDefinition($this->prefix('entityLocator'))
+			->setClass('Kdyby\Doctrine\DI\EntityLocator')
+			->setAutowired(FALSE);
 	}
 
 
@@ -706,8 +710,9 @@ class OrmExtension extends Nette\DI\CompilerExtension
 				$entityArgument = $boundEntity;
 
 			} else {
-				$entityArgument = new Code\PhpLiteral('"%entityName%"');
-				$this->postCompileRepositoriesQueue[$boundManagers[0]][] = [ltrim($originalDef->getClass(), '\\'), $originalServiceName];
+				$repository = ltrim($originalDef->getClass(), '\\');
+				$entityArgument = new Statement('$this->getService(?)->get(?)', [$this->prefix('entityLocator'), $repository]);
+				$this->postCompileRepositoriesQueue[$boundManagers[0]][] = [$repository, $originalServiceName];
 			}
 
 			$builder->removeDefinition($originalServiceName);
@@ -773,67 +778,16 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			$init->addBody($originalInitialize);
 		}
 
-		$this->processRepositoryFactoryEntities($class);
-	}
+		$classNames = array_map(function ($config) {
+			return $config['defaultRepositoryClassName'];
+		}, $this->managerConfigs);
 
-
-
-	protected function processRepositoryFactoryEntities(Code\ClassType $class)
-	{
-		if (empty($this->postCompileRepositoriesQueue)) {
-			return;
-		}
-
-		$dic = self::evalAndInstantiateContainer($class);
-
-		foreach ($this->postCompileRepositoriesQueue as $manager => $items) {
-			$config = $this->managerConfigs[$manager];
-			/** @var Kdyby\Doctrine\EntityManager $entityManager */
-			$entityManager = $dic->getService($this->configuredManagers[$manager]);
-			/** @var Doctrine\ORM\Mapping\ClassMetadata $entityMetadata */
-			$metadataFactory = $entityManager->getMetadataFactory();
-
-			$allMetadata = [];
-			foreach ($metadataFactory->getAllMetadata() as $entityMetadata) {
-				if ($config['defaultRepositoryClassName'] === $entityMetadata->customRepositoryClassName || empty($entityMetadata->customRepositoryClassName)) {
-					continue;
-				}
-
-				$allMetadata[ltrim($entityMetadata->customRepositoryClassName, '\\')] = $entityMetadata;
-			}
-
-			foreach ($items as $item) {
-				if (!isset($allMetadata[$item[0]])) {
-					throw new Nette\Utils\AssertionException(sprintf('Repository class %s have been found in DIC, but no entity has it assigned and it has no entity configured', $item[0]));
-				}
-
-				$entityMetadata = $allMetadata[$item[0]];
-				$serviceMethod = Nette\DI\Container::getMethodName($item[1]);
-
-				$method = $class->getMethod($serviceMethod);
-				$methodBody = $method->getBody();
-				$method->setBody(str_replace('"%entityName%"', Code\Helpers::format('?', $entityMetadata->getName()), $methodBody));
-			}
-		}
-	}
-
-
-
-	/**
-	 * @param Code\ClassType $class
-	 * @return Nette\DI\Container
-	 */
-	private static function evalAndInstantiateContainer(Code\ClassType $class)
-	{
-		$classCopy = clone $class;
-		$classCopy->setName($className = 'Kdyby_Doctrine_IamTheKingOfHackingNette_' . $class->getName() . '_' . rand());
-
-		$containerCode = "$classCopy";
-
-		return call_user_func(function () use ($className, $containerCode) {
-			eval($containerCode);
-			return new $className();
-		});
+		$init->addBody('$this->getService(?)->setup($this, ?, ?, ?);', [
+			$this->prefix('entityLocator'),
+			$this->postCompileRepositoriesQueue,
+			$classNames,
+			$this->configuredManagers,
+		]);
 	}
 
 


### PR DESCRIPTION
Hi Filip,

First, thank you for a great Nette extension Kdyby/Doctrine!

But I've got some kind of problems when I register a repository as a service (i.e. in a config file).

The reason is DIC is evaluated at a compile time [here](https://github.com/Kdyby/Doctrine/compare/master...hranicka:feature/dic-hacking?expand=1#diff-ccc8ba07edfa3a425ddfe564acb50656L777).

The problem is that some code is lauchned twice (i.e. [Kdyby\Events Tracy Panel registration](http://i.imgur.com/9V3BwCR.png)).

It's a problem only at a compile-time, but I've had [another issue](https://github.com/nette/application/issues/110#issuecomment-222605730) and my DIC was rebuilt for every application request (in a debug mode only).

---

I've refactored the code and removed DIC evaluating at a compile-time.

Because there are [some expensive operations](https://github.com/Kdyby/Doctrine/compare/master...hranicka:feature/dic-hacking?expand=1#diff-ccc8ba07edfa3a425ddfe564acb50656L777) and now the code is launched at a run-time, I've added caching in there.

Now the code in a production should be as fast as previously (DIC evaluating and generated PHP class changes vs. repository mapping and caching the map). And DIC is evaluated as should be - only at runtime.

What do you think?
