### PR TITLE
OrmExtensions: Repository magic removed [BC-break] [WIP]

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -134,11 +134,6 @@ class OrmExtension extends Nette\DI\CompilerExtension
 	 */
 	private $configuredConnections = [];
 
-	/**
-	 * @var array
-	 */
-	private $postCompileRepositoriesQueue = [];
-
 
 
 	public function loadConfiguration()
@@ -147,8 +142,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		$this->targetEntityMappings =
 		$this->configuredConnections =
 		$this->managerConfigs =
-		$this->configuredManagers =
-		$this->postCompileRepositoriesQueue = [];
+		$this->configuredManagers = [];
 
 		if (!$this->compiler->getExtensions('Kdyby\Annotations\DI\AnnotationsExtension')) {
 			throw new Nette\Utils\AssertionException('You should register \'Kdyby\Annotations\DI\AnnotationsExtension\' before \'' . get_class($this) . '\'.', E_USER_NOTICE);
@@ -706,8 +700,8 @@ class OrmExtension extends Nette\DI\CompilerExtension
 				$entityArgument = $boundEntity;
 
 			} else {
+				// TODO Obtain an Entity FQN w/o ClassMetadataFactory::getAllMetadata invoking or should it be done another faster way?
 				$entityArgument = new Code\PhpLiteral('"%entityName%"');
-				$this->postCompileRepositoriesQueue[$boundManagers[0]][] = [ltrim($originalDef->getClass(), '\\'), $originalServiceName];
 			}
 
 			$builder->removeDefinition($originalServiceName);
@@ -772,68 +766,6 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			$init->setBody('Kdyby\Doctrine\Proxy\ProxyAutoloader::create(?, ?)->register();', [$dir, $namespace]);
 			$init->addBody($originalInitialize);
 		}
-
-		$this->processRepositoryFactoryEntities($class);
-	}
-
-
-
-	protected function processRepositoryFactoryEntities(Code\ClassType $class)
-	{
-		if (empty($this->postCompileRepositoriesQueue)) {
-			return;
-		}
-
-		$dic = self::evalAndInstantiateContainer($class);
-
-		foreach ($this->postCompileRepositoriesQueue as $manager => $items) {
-			$config = $this->managerConfigs[$manager];
-			/** @var Kdyby\Doctrine\EntityManager $entityManager */
-			$entityManager = $dic->getService($this->configuredManagers[$manager]);
-			/** @var Doctrine\ORM\Mapping\ClassMetadata $entityMetadata */
-			$metadataFactory = $entityManager->getMetadataFactory();
-
-			$allMetadata = [];
-			foreach ($metadataFactory->getAllMetadata() as $entityMetadata) {
-				if ($config['defaultRepositoryClassName'] === $entityMetadata->customRepositoryClassName || empty($entityMetadata->customRepositoryClassName)) {
-					continue;
-				}
-
-				$allMetadata[ltrim($entityMetadata->customRepositoryClassName, '\\')] = $entityMetadata;
-			}
-
-			foreach ($items as $item) {
-				if (!isset($allMetadata[$item[0]])) {
-					throw new Nette\Utils\AssertionException(sprintf('Repository class %s have been found in DIC, but no entity has it assigned and it has no entity configured', $item[0]));
-				}
-
-				$entityMetadata = $allMetadata[$item[0]];
-				$serviceMethod = Nette\DI\Container::getMethodName($item[1]);
-
-				$method = $class->getMethod($serviceMethod);
-				$methodBody = $method->getBody();
-				$method->setBody(str_replace('"%entityName%"', Code\Helpers::format('?', $entityMetadata->getName()), $methodBody));
-			}
-		}
-	}
-
-
-
-	/**
-	 * @param Code\ClassType $class
-	 * @return Nette\DI\Container
-	 */
-	private static function evalAndInstantiateContainer(Code\ClassType $class)
-	{
-		$classCopy = clone $class;
-		$classCopy->setName($className = 'Kdyby_Doctrine_IamTheKingOfHackingNette_' . $class->getName() . '_' . rand());
-
-		$containerCode = "$classCopy";
-
-		return call_user_func(function () use ($className, $containerCode) {
-			eval($containerCode);
-			return new $className();
-		});
 	}
 
 

--- a/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
+++ b/tests/KdybyTests/Doctrine/RepositoryFactory.phpt
@@ -82,22 +82,6 @@ class RepositoryFactoryTest extends Tester\TestCase
 
 
 
-	public function testCustomRepository_withoutService()
-	{
-		$container = $this->createContainer('repository-factory.without-service');
-
-		/** @var \Kdyby\Doctrine\EntityManager $em */
-		$em = $container->getByType('Kdyby\Doctrine\EntityManager');
-
-		$cmsCommentRepository = $em->getRepository('KdybyTests\Doctrine\CmsComment');
-		Assert::type('KdybyTests\Doctrine\CmsCommentRepository', $cmsCommentRepository);
-		Assert::type('Kdyby\Doctrine\EntityRepository', $cmsCommentRepository);
-		Assert::same('KdybyTests\Doctrine\CmsComment', $cmsCommentRepository->getClassName());
-		Assert::same('KdybyTests\Doctrine\CmsComment', $cmsCommentRepository->getClassMetadata()->getName());
-	}
-
-
-
 	public function testManualRegistration()
 	{
 		$container = $this->createContainer('repository-factory.manual');

--- a/tests/KdybyTests/Doctrine/config/repository-factory.without-service.neon
+++ b/tests/KdybyTests/Doctrine/config/repository-factory.without-service.neon
@@ -1,6 +1,0 @@
-kdyby.doctrine:
-	driver: pdo_sqlite
-	memory: true
-	metadata:
-		KdybyTests\Doctrine: annotations(%appDir%/Doctrine/models)
-	defaultRepositoryClassName: Kdyby\Doctrine\EntityRepository


### PR DESCRIPTION
Because of unnecessary magic, huge performance impact and #274, I've removed **part of Repository magic** inside this library.

This is a BC-break, because we need register every Repository which we need inject from DIC.

My DIC is compiled several times faster now.
## 

**WORK IN PROGRESS**, it's a quite complex.
