### PR TITLE
QueryObject::count returns always integer

### DIFF
--- a/src/Kdyby/Doctrine/QueryObject.php
+++ b/src/Kdyby/Doctrine/QueryObject.php
@@ -130,7 +130,7 @@ abstract class QueryObject extends Nette\Object implements Kdyby\Persistence\Que
 	public function count(Queryable $repository, ResultSet $resultSet = NULL, Paginator $paginatedQuery = NULL)
 	{
 		if ($query = $this->doCreateCountQuery($repository)) {
-			return $this->toQuery($query)->getSingleScalarResult();
+			return (int)$this->toQuery($query)->getSingleScalarResult();
 		}
 
 		if ($this->lastQuery && $this->lastQuery instanceof NativeQueryWrapper) {


### PR DESCRIPTION
Function `QueryObject::count` should always return integer, because `ResultSet::getTotalCount` expects (and also should return) integer. At this moment `getSingleScalarResult` may return `"0"` and this means that function `ResultSet::isEmpty` returns `false` (but should return `true`).