### PR TITLE
Default EntityManager and/or Connection

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -236,9 +236,11 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		$builder = $this->getContainerBuilder();
 		$config = $this->resolveConfig($defaults, $this->managerDefaults, $this->connectionDefaults);
 
-		if ($isDefault = !isset($builder->parameters[$this->name]['orm']['defaultEntityManager'])) {
+		if (!isset($builder->parameters[$this->name]['orm']['defaultEntityManager'])) {
 			$builder->parameters[$this->name]['orm']['defaultEntityManager'] = $name;
 		}
+
+		$isDefault = $name === $builder->parameters[$this->name]['orm']['defaultEntityManager'];
 
 		$metadataDriver = $builder->addDefinition($this->prefix($name . '.metadataDriver'))
 			->setClass('Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain')
@@ -367,7 +369,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		$entityManager = $builder->addDefinition($managerServiceId = $this->prefix($name . '.entityManager'))
 			->setClass('Kdyby\Doctrine\EntityManager')
 			->setFactory('Kdyby\Doctrine\EntityManager::create', [
-				$connectionService = $this->processConnection($name, $defaults, $isDefault),
+				$connectionService = $this->processConnection($name, $defaults),
 				$this->prefix('@' . $name . '.ormConfiguration'),
 				$this->prefix('@' . $name . '.evm'),
 			])
@@ -484,14 +486,16 @@ class OrmExtension extends Nette\DI\CompilerExtension
 
 
 
-	protected function processConnection($name, array $defaults, $isDefault = FALSE)
+	protected function processConnection($name, array $defaults)
 	{
 		$builder = $this->getContainerBuilder();
 		$config = $this->resolveConfig($defaults, $this->connectionDefaults, $this->managerDefaults);
 
-		if ($isDefault) {
+		if (!isset($builder->parameters[$this->name]['dbal']['defaultConnection'])) {
 			$builder->parameters[$this->name]['dbal']['defaultConnection'] = $name;
 		}
+
+		$isDefault = $name === $builder->parameters[$this->name]['dbal']['defaultConnection'];
 
 		if (isset($defaults['connection'])) {
 			return $this->prefix('@' . $defaults['connection'] . '.connection');


### PR DESCRIPTION
Hi,

I've more EntityManager and Connection instances in an application.
It works fine until I set some of them in a separated (included) configuration file (neon).

In this case these additional setups are processed before the main configuration file and a default connection is not as before therefore.

---

I've made only as few changes as possible. It should be w/o any BC-break (except the changed behavior for included config files).

Maybe it should be forced to use `default` EntityManager and Connection, not the first found configuration.

It shoud be configurable better in an extension configuration section rather than in a parameters section.
