### PR TITLE
Persist correctly non required property in readOnly entities

### DIFF
--- a/tests/KdybyTests/Doctrine/Extension.phpt
+++ b/tests/KdybyTests/Doctrine/Extension.phpt
@@ -98,6 +98,7 @@ class ExtensionTest extends Tester\TestCase
 			'KdybyTests\\Doctrine\\CmsOrder',
 			'KdybyTests\\Doctrine\\CmsPhoneNumber',
 			'KdybyTests\\Doctrine\\CmsUser',
+			'KdybyTests\\Doctrine\\ReadOnlyEntity',
 			'KdybyTests\\Doctrine\\StiAdmin',
 			'KdybyTests\\Doctrine\\StiBoss',
 			'KdybyTests\\Doctrine\\StiEmployee',

--- a/tests/KdybyTests/Doctrine/NonLockingUniqueInserter.phpt
+++ b/tests/KdybyTests/Doctrine/NonLockingUniqueInserter.phpt
@@ -19,6 +19,7 @@ use Tester\Assert;
 require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/models/cms.php';
 require_once __DIR__ . '/models/sti.php';
+require_once __DIR__ . '/models/edgeCaseEntities.php';
 
 
 
@@ -113,6 +114,24 @@ class NonLockingUniqueInserterTest extends KdybyTests\Doctrine\ORMTestCase
 
 		$row = $em->getConnection()->fetchAssoc('SELECT * FROM sti_users WHERE id = :id', [ 'id' => $boss->id ]);
 		Assert::equal('boss', $row['type']);
+	}
+
+
+
+	public function testSavingAllPropertiesOnReadOnlyEntities()
+	{
+		$em = $this->createMemoryManager();
+
+		$nonRequiredValue = 'nonRequired';
+		$requiredValue = 'required';
+
+		$entity = new ReadOnlyEntity(1, $nonRequiredValue, $requiredValue);
+		$em->safePersist($entity);
+		$em->clear();
+
+		$row = $em->getConnection()->fetchAssoc('SELECT * FROM read_only_entities WHERE id = :id', ['id' => 1]);
+		Assert::same($nonRequiredValue, $row['non_required']);
+		Assert::same($requiredValue, $row['required']);
 	}
 
 }

--- a/tests/KdybyTests/Doctrine/models/edgeCaseEntities.php
+++ b/tests/KdybyTests/Doctrine/models/edgeCaseEntities.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the Kdyby (http://www.kdyby.org)
+ *
+ * Copyright (c) 2008 Filip Procházka (filip@prochazka.su)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
+ */
+
+namespace KdybyTests\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(readOnly=TRUE)
+ * @ORM\Table(name="read_only_entities")
+ */
+class ReadOnlyEntity
+{
+
+	/**
+	 * @ORM\Column(type="integer")
+	 * @ORM\Id
+	 * @ORM\GeneratedValue
+	 */
+	private $id;
+
+	/**
+	 * @ORM\Column(length=50, nullable=TRUE)
+	 */
+	public $nonRequired;
+
+	/**
+	 * @ORM\Column(length=50, nullable=FALSE)
+	 */
+	public $required;
+
+
+
+	/**
+	 * @param $id
+	 * @param $nonRequired
+	 * @param $required
+	 */
+	public function __construct($id, $nonRequired, $required)
+	{
+		$this->id = $id;
+		$this->nonRequired = $nonRequired;
+		$this->required = $required;
+	}
+
+}
+
+


### PR DESCRIPTION
If i have readOnly entity which have non required properties, I want to persist their value too.

Unfortunatelly i am not capable of find a bug. What I know is - it is start to happened when we migrate doctrine/dbal from 2.4.2 to 2.4.3 (around 6th November 2014).

By the way, if I use classic persist from kdyby/doctrine everything is correctly persisted in DB.