### PR TITLE
Geo\Element: fixed validation for long geo-strings

### DIFF
--- a/tests/KdybyTests/Doctrine/Geo/Element.phpt
+++ b/tests/KdybyTests/Doctrine/Geo/Element.phpt
@@ -84,6 +84,19 @@ class ElementTest extends Tester\TestCase
 		Assert::type("string", $property->getValue($element2));
 	}
 
+
+
+	public function testLongStringValue()
+	{
+		$stringValue = 'POLYGON((50.1049501 14.4862063' . str_repeat(', 50.1049501 14.4862063', 100000) . '))';
+		$element = Element::fromString($stringValue);
+
+		Assert::noError(function () use ($element) {
+			// force string validation
+			$element->freeze();
+		});
+	}
+
 }
 
 


### PR DESCRIPTION
The original one-pass regexp fails with "Failed due to limited JIT stack space (pattern: ~^(?P<name>\w+)\(\(?(?P<coords>(?:[\d\.]+\s* \s*[\d\.]+)(?:\s*,\s*[\d\.]+\s* \s*[\d\.]+)*)\)?\)$~i)".
Alternative one-letter solution that uses ungreedy modifier only postpones the problem to longer strings.