### PR TITLE
Add auto search for annotation extension name

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -622,15 +622,8 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		}
 
 		if ($impl === self::ANNOTATION_DRIVER) {
-			$annotationExtensionName = self::ANNOTATION_DRIVER;
-			foreach ($this->compiler->getExtensions(AnnotationsExtension::class) as $annotationExtension) {
-				$annotationExtensionName = $annotationExtension->name;
-
-				break;
-			}
-
 			$driver->arguments = [
-				"@{$annotationExtensionName}.reader",
+				'@' . Doctrine\Common\Annotations\Reader::class,
 				Nette\Utils\Arrays::flatten($driver->arguments)
 			];
 		}

--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -622,8 +622,15 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		}
 
 		if ($impl === self::ANNOTATION_DRIVER) {
+			$annotationExtensionName = self::ANNOTATION_DRIVER;
+			foreach ($this->compiler->getExtensions(AnnotationsExtension::class) as $annotationExtension) {
+				$annotationExtensionName = $annotationExtension->name;
+
+				break;
+			}
+
 			$driver->arguments = [
-				'@' . self::ANNOTATION_DRIVER . '.reader',
+				"@{$annotationExtensionName}.reader",
 				Nette\Utils\Arrays::flatten($driver->arguments)
 			];
 		}

--- a/tests/KdybyTests/Doctrine/config/proxiesSessionAutoloading.neon
+++ b/tests/KdybyTests/Doctrine/config/proxiesSessionAutoloading.neon
@@ -1,4 +1,4 @@
-console:
+kdyby.console:
 	disabled: true
 
 kdyby.doctrine:

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -3,9 +3,9 @@ php:
 
 
 extensions:
-	events: Kdyby\Events\DI\EventsExtension
-	console: Kdyby\Console\DI\ConsoleExtension
-	annotations: Kdyby\Annotations\DI\AnnotationsExtension
+	kdyby.events: Kdyby\Events\DI\EventsExtension
+	kdyby.console: Kdyby\Console\DI\ConsoleExtension
+	kdyby.annotations: Kdyby\Annotations\DI\AnnotationsExtension
 	kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
 
 
@@ -16,7 +16,7 @@ kdyby.doctrine:
 	hydrationCache: array
 
 
-console:
+kdyby.console:
 	url: http://www.kdyby.org/
 
 


### PR DESCRIPTION
Bug fix: yes

Previous version did not depend on name of annotation extension. After #311 Kdyby/Doctrine search for extension with name 'annotations'.

It is not compatible with following extension configuration:
```yml
extensions:
  kdyby.events: Kdyby\Events\DI\EventsExtension
  kdyby.annotations: Kdyby\Annotations\DI\AnnotationsExtension
  kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
```