### PR TITLE
Fix empty metadata (annotation driver)

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -295,7 +295,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 			$metadataDriver->addSetup('setDefaultDriver', [
 				new Statement($this->metadataDriverClasses[self::ANNOTATION_DRIVER], [
 					'@' . Doctrine\Common\Annotations\Reader::class,
-					[Nette\DI\Helpers::expand('%appDir%', $builder->parameters)]
+					[$builder->expand('%appDir%')]
 				])
 			]);
 		}

--- a/tests/KdybyTests/Doctrine/config/metadata-empty.neon
+++ b/tests/KdybyTests/Doctrine/config/metadata-empty.neon
@@ -1,5 +1,5 @@
 parameters:
-	appDir: %wwwDir%/Doctrine/models2 # appDir replacing required - AnnotationDriver::getAllClassNames() require problem
+	appDir: %wwwDir%/Doctrine/models2
 
 kdyby.doctrine:
 	driver: pdo_sqlite


### PR DESCRIPTION
Bugfix: yes

After PR #311 there is problem with empty config metadata e.g.:

```yaml
doctrine:
    metadata: [] # empty or missing
```