### PR TITLE
fixing negative coordinates

### DIFF
--- a/src/Kdyby/Doctrine/Geo/Element.php
+++ b/src/Kdyby/Doctrine/Geo/Element.php
@@ -244,7 +244,7 @@ class Element
 
 		$separator = $this->separator;
 		$coordsSeparator = $this->coordsSeparator;
-		$coordsRegexp = '~^\s*[\d\.]+\s*' . preg_quote($coordsSeparator) . '\s*[\d\.]+\s*$~i';
+		$coordsRegexp = '~^\s*-?[\d\.]+\s*' . preg_quote($coordsSeparator) . '\s*-?[\d\.]+\s*$~i';
 
 		$coordinates = [];
 		foreach (explode($separator, $coordsList) as $coords) {


### PR DESCRIPTION
Dobrý den :)

při používání knihovny jsme narazili na zajímavou věc, nelze používat geo/Element se zápornými souřadnicemi :) (cokoliv od Greenwich na západ a od rovníku dolů. :) )

Tohle nám to opravilo, tak snad nebudete proti. :)