### PR TITLE
Fix composer requirements to existing version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "kdyby/strict-objects": "^2.0",
     "nette/di": "^3.0",
     "nette/utils": "^3.0",
-    "nette/finder": "^3.0"
+    "nette/finder": "^2.5"
   },
   "suggest": {
     "kdyby/doctrine-magic-accessors": "Fast-prototyping magic accessors trait for Doctrine entities",
@@ -39,7 +39,7 @@
     "nette/bootstrap": "^3.0",
     "nette/caching": "^3.0",
     "nette/http": "^3.0",
-    "tracy/tracy": "^3.0",
+    "tracy/tracy": "^2.5",
     "nette/tester": "^2.2"
   },
   "minimum-stability": "dev",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,4 @@ parameters:
 		- '#Call to an undefined method Reflector::get#' # TODO refactoring class Panel
 		- '#Call to an undefined method object::getId\(\)#' # class SimpleParameterFormatter
 		- '#Method Kdyby\\Doctrine\\NativeQueryBuilder::(join|where|andWhere|orWhere)\(\) should return \$this but returns call_user_func_array#' # NativeQueryBuilder shortcuts
+		- '#Parameter \#1 \$parameters of method Doctrine\\ORM\\AbstractQuery::setParameters\(\) expects Doctrine\\Common\\Collections\\ArrayCollection&iterable, array given\.#'

--- a/src/Kdyby/Doctrine/Diagnostics/Panel.php
+++ b/src/Kdyby/Doctrine/Diagnostics/Panel.php
@@ -337,7 +337,7 @@ class Panel implements IBarPanel, Doctrine\DBAL\Logging\SQLLogger
 			if ($e->query instanceof Doctrine\ORM\Query) {
 				return [
 					'tab' => 'DQL',
-					'panel' => $this->dumpQuery($e->query->getDQL(), $e->query->getParameters()),
+					'panel' => $this->dumpQuery((string) $e->query->getDQL(), $e->query->getParameters()),
 				];
 
 			} elseif ($e->query instanceof Kdyby\Doctrine\NativeQueryWrapper) {

--- a/src/Kdyby/Doctrine/ResultSet.php
+++ b/src/Kdyby/Doctrine/ResultSet.php
@@ -173,7 +173,7 @@ class ResultSet implements \Countable, \IteratorAggregate
 		$this->updating();
 
 		if ($this->query instanceof ORM\Query) {
-			$dql = Strings::normalize($this->query->getDQL());
+			$dql = Strings::normalize((string) $this->query->getDQL());
 			if (preg_match('~^(.+)\\s+(ORDER BY\\s+((?!FROM|WHERE|ORDER\\s+BY|GROUP\\sBY|JOIN).)*)\\z~si', $dql, $m)) {
 				$dql = $m[1];
 			}
@@ -207,7 +207,7 @@ class ResultSet implements \Countable, \IteratorAggregate
 		}
 
 		if ($sorting && $this->query instanceof ORM\Query) {
-			$dql = Strings::normalize($this->query->getDQL());
+			$dql = Strings::normalize((string) $this->query->getDQL());
 
 			if (!preg_match('~^(.+)\\s+(ORDER BY\\s+((?!FROM|WHERE|ORDER\\s+BY|GROUP\\sBY|JOIN).)*)\\z~si', $dql, $m)) {
 				$dql .= ' ORDER BY ';

--- a/tests/KdybyTests/Doctrine/Console/GenerateEntitiesCommand.phpt
+++ b/tests/KdybyTests/Doctrine/Console/GenerateEntitiesCommand.phpt
@@ -42,7 +42,7 @@ class GenerateEntitiesCommandTest extends CommandTestCase
 			Assert::contains("Processing entity \"{$entity}\"", $output);
 		}
 		Assert::notContains(sprintf('Processing entity "%s"', \KdybyTests\Doctrine\Models2\Foo::class), $output);
-		Assert::contains('Entity classes generated to "' . realpath($destDir) . '"', $output);
+		Assert::contains('Entity classes generated to "' . realpath($destDir), $output);
 	}
 
 
@@ -64,7 +64,7 @@ class GenerateEntitiesCommandTest extends CommandTestCase
 
 		Assert::notContains('Processing entity "' . self::$entities[0] . '"', $output);
 		Assert::contains(sprintf('Processing entity "%s"', \KdybyTests\Doctrine\Models2\Foo::class), $output);
-		Assert::contains('Entity classes generated to "' . realpath($destDir) . '"', $output);
+		Assert::contains('Entity classes generated to "' . realpath($destDir), $output);
 	}
 
 }


### PR DESCRIPTION
Fixes the issue with composer.json referencing non-existing versions of nette/finder and tracy/tracy, reported by @simPod in https://github.com/Kdyby/Doctrine/pull/330#issuecomment-546520498_

Also, several casting and one phpstan ignore were added, because of types of doctrine/* packages. These were neccessary to pass the tests.