### PR TITLE
OrmExtension: fix deprecated definition

### DIFF
--- a/src/Kdyby/Doctrine/DI/OrmExtension.php
+++ b/src/Kdyby/Doctrine/DI/OrmExtension.php
@@ -458,7 +458,7 @@ class OrmExtension extends Nette\DI\CompilerExtension
 		}
 
 		$builder->addDefinition($this->prefix($name . '.cacheRegionsConfiguration'))
-			->setClass(Doctrine\ORM\Cache\RegionsConfiguration::class, [
+			->setFactory(Doctrine\ORM\Cache\RegionsConfiguration::class, [
 				$config['regions']['defaultLifetime'],
 				$config['regions']['defaultLockLifetime'],
 			])


### PR DESCRIPTION
I've fixed error `Service doctrine.default.cacheRegionsConfiguration: Nette\DI\Definitions\ServiceDefinition::setClass() second parameter $args is deprecated, use setFactory()` as error message suggests.