### PR TITLE
Possible update for kdyby/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^7.1",
     "doctrine/orm": "~2.7",
     "doctrine/dbal": "~2.9",
-    "kdyby/console": "^2.7.1",
+    "kdyby/console": "^2.7.1 || ^4.0.0",
     "kdyby/annotations": "^3.0",
     "kdyby/doctrine-cache": "^3.0",
     "kdyby/strict-objects": "^2.0",

--- a/src/Kdyby/Doctrine/DI/IRepositoryFactory.php
+++ b/src/Kdyby/Doctrine/DI/IRepositoryFactory.php
@@ -22,12 +22,5 @@ use Nette;
  */
 interface IRepositoryFactory
 {
-
-	/**
-	 * @param ORM\EntityManagerInterface $entityManager
-	 * @param ORM\Mapping\ClassMetadata $classMetadata
-	 * @return EntityRepository
-	 */
-	public function create(ORM\EntityManagerInterface $entityManager, ORM\Mapping\ClassMetadata $classMetadata);
-
+	public function create(ORM\EntityManagerInterface $em, ORM\Mapping\ClassMetadata $class): EntityRepository;
 }


### PR DESCRIPTION
Optional update of kdyby/console to version 4.0.0 to solve issue https://github.com/Kdyby/Events/issues/132 where old version of kdyby/console does not allow run migrations via console using nettrine/migrations